### PR TITLE
Add global Qt theme palette

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,8 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt
 
+from AnnoMate.styles import MAIN_STYLESHEET
+
 # Local Application Imports
 from AnnoMate.adapter import AnnotatorTab
 from MicroSentryAI.adapter import MicroSentryTab
@@ -149,6 +151,14 @@ def main():
     # QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
 
     app = QApplication(sys.argv)
+    
+    # Force Qt to prefer light appearance instead of following OS dark mode.
+    style_hints = app.styleHints()
+    if hasattr(style_hints, "setColorScheme"):
+        style_hints.setColorScheme(Qt.ColorScheme.Light)
+
+    # Apply the app's existing light-themed stylesheet globally.
+    app.setStyleSheet(MAIN_STYLESHEET)
     
     main_window = AppWindow()
     main_window.showMaximized()


### PR DESCRIPTION
## Summary
Adds a global Qt theme setup so the main application UI uses a consistent palette across operating systems.

## What changed
- Forces existing light mode styles with Pyside6 in main.py.

## Why
This reduces dependency on OS-level light/dark mode behavior and helps keep text/background colors readable and consistent across macOS and Windows.

## Notes
- The main interface now uses a forced Qt theme rather than relying on native appearance defaults.
- No core application logic was changed.