### PR TITLE
Project Persistence - Save, Load & Autosave

### DIFF
--- a/src/controllers/inference_controller.py
+++ b/src/controllers/inference_controller.py
@@ -136,6 +136,7 @@ class InferenceController(QObject):
         self._strategy_class = strategy_class
         self._strategy = None
         self._worker: Optional[InferenceWorker] = None
+        self._model_path: str = ""
 
     # ------------------------------------------------------------------ #
     # Model management
@@ -163,16 +164,17 @@ class InferenceController(QObject):
         strategy.set_device(device.lower())
         strategy.load_from_file(model_path)   # raises on failure
         self._strategy = strategy
+        self._model_path = model_path
         logger.info("Model loaded: %s", strategy.model_name)
         return strategy.model_name
 
     def get_model_name(self) -> str:
-        """Return the name of the currently loaded model.
-
-        Returns:
-            str: Model name string, or an empty string if no model is loaded.
-        """
+        """Return the name of the currently loaded model, or empty string."""
         return self._strategy.model_name if self._strategy else ""
+
+    def get_model_path(self) -> str:
+        """Return the file path of the currently loaded model, or empty string."""
+        return self._model_path
 
     def has_model(self) -> bool:
         """Check whether a model has been successfully loaded.

--- a/src/controllers/project_controller.py
+++ b/src/controllers/project_controller.py
@@ -1,0 +1,378 @@
+"""
+ProjectController — owns the project save/load lifecycle.
+
+Rules (consistent with existing controllers):
+  - No Qt GUI types (no QFileDialog, QMessageBox). All dialogs live in views.
+  - Accepts plain Python values; callers handle user-facing display.
+  - QObject/Signal is permitted as infrastructure, not UI.
+  - State is mutated directly for bulk operations (same pattern as IOController),
+    but a single model reset is emitted at the end so views update atomically.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from PySide6.QtCore import QObject, Signal
+
+from core.persistence.autosave import AutosaveManager
+from core.persistence.project_io import ProjectIO
+
+logger = logging.getLogger("AnnoMate.ProjectController")
+
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff"}
+
+
+class ProjectController(QObject):
+    """Own the project save/load lifecycle and autosave timer.
+
+    Encapsulates ProjectIO and AutosaveManager. Accepts all three models
+    so it can read state directly for saves and mutate state for loads —
+    the same bulk-mutation pattern used by IOController. Emits a single
+    model reset after load so views refresh atomically with complete data.
+
+    Dirty tracking is managed here rather than in AppWindow. The _loading
+    guard suppresses dirty signals that fire during the load sequence itself.
+
+    Attributes:
+        dataset_model: DatasetTableModel.
+        inference_model: InferenceModel.
+        validation_model: ValidationModel.
+        io_controller: IOController (used for image-dir scans).
+        inference_controller: InferenceController (for model_path tracking).
+
+    Signals:
+        dirty_changed (bool): Emitted when the dirty flag changes state.
+        project_opened (str): Emitted with the project name after a successful open.
+        project_saved (str): Emitted with the .annoproj path after a successful save.
+        autosave_written (str): Emitted with the autosave path on success.
+        autosave_failed (str): Emitted with an error message on autosave failure.
+    """
+
+    dirty_changed    = Signal(bool)
+    project_opened   = Signal(str)   # project_name
+    project_saved    = Signal(str)   # annoproj_path
+    autosave_written = Signal(str)   # autosave annoproj path
+    autosave_failed  = Signal(str)   # error message
+
+    def __init__(
+        self,
+        dataset_model,
+        inference_model,
+        validation_model,
+        io_controller,
+        inference_controller=None,
+        parent: QObject = None,
+    ) -> None:
+        super().__init__(parent)
+        self._dataset_model = dataset_model
+        self._inference_model = inference_model
+        self._validation_model = validation_model
+        self._io_controller = io_controller
+        self._inference_controller = inference_controller
+
+        self._project_io = ProjectIO()
+        self._autosave_manager = AutosaveManager(interval_minutes=5, parent=self)
+        self._autosave_manager.save_requested.connect(self._do_autosave)
+
+        self._project_dir: Optional[str] = None
+        self._project_name: str = ""
+        self._created_at: Optional[str] = None
+        self._is_dirty: bool = False
+        self._loading: bool = False
+
+        # Connect model signals for dirty tracking. The _loading guard
+        # suppresses spurious dirty events fired during our own load sequence.
+        self._dataset_model.dataChanged.connect(self._on_model_changed)
+        self._dataset_model.modelReset.connect(self._on_model_changed)
+
+    # ------------------------------------------------------------------ #
+    # Properties (read-only for AppWindow)
+    # ------------------------------------------------------------------ #
+
+    @property
+    def is_dirty(self) -> bool:
+        return self._is_dirty
+
+    @property
+    def project_dir(self) -> Optional[str]:
+        return self._project_dir
+
+    @property
+    def project_name(self) -> str:
+        return self._project_name
+
+    @property
+    def has_project(self) -> bool:
+        return self._project_dir is not None
+
+    @property
+    def autosave_manager(self) -> AutosaveManager:
+        return self._autosave_manager
+
+    # ------------------------------------------------------------------ #
+    # Dirty tracking
+    # ------------------------------------------------------------------ #
+
+    def mark_dirty(self) -> None:
+        """Mark the project as having unsaved changes."""
+        if self._loading:
+            return
+        if not self._is_dirty:
+            self._is_dirty = True
+            self.dirty_changed.emit(True)
+
+    def clear_dirty(self) -> None:
+        """Mark the project as clean (all changes saved)."""
+        if self._is_dirty:
+            self._is_dirty = False
+            self.dirty_changed.emit(False)
+
+    def _on_model_changed(self, *args) -> None:
+        self.mark_dirty()
+
+    # ------------------------------------------------------------------ #
+    # New / Open / Save
+    # ------------------------------------------------------------------ #
+
+    def new_project(self) -> None:
+        """Clear all state and reset project tracking.
+
+        Callers should check is_dirty and prompt the user before calling this.
+        """
+        state = self._dataset_model.state
+        state.clear()
+        self._inference_model.state.clear()
+        self._validation_model.state.clear()
+
+        self._loading = True
+        try:
+            self._dataset_model.beginResetModel()
+            self._dataset_model.endResetModel()
+        finally:
+            self._loading = False
+
+        self._project_dir = None
+        self._project_name = ""
+        self._created_at = None
+        self._autosave_manager.stop()
+        self.clear_dirty()
+
+    def open_project(self, annoproj_path: str) -> Tuple[dict, List[str]]:
+        """Load and apply a project file.
+
+        Performs a single atomic model reset after all state is populated,
+        avoiding the double-reset flicker of calling load_folder first.
+        Returns (project_data, warnings). Raises on file read errors.
+
+        Callers should check is_dirty and prompt the user before calling this.
+
+        Args:
+            annoproj_path: Absolute path to the .annoproj file.
+
+        Returns:
+            Tuple of (project_data dict, list of warning strings).
+            project_data contains 'inference.model_path' if a model was previously saved.
+
+        Raises:
+            FileNotFoundError, json.JSONDecodeError: On unreadable project file.
+        """
+        project_data = self._project_io.load_project(annoproj_path)
+        image_dir = project_data.get("dataset", {}).get("image_dir", "")
+        warnings: List[str] = []
+
+        self._loading = True
+        try:
+            ds = self._dataset_model.state
+            ds.clear()
+
+            if image_dir and os.path.isdir(image_dir):
+                files = sorted(
+                    f for f in os.listdir(image_dir)
+                    if Path(f).suffix.lower() in _IMAGE_EXTENSIONS
+                )
+                ds.image_dir = image_dir
+                ds.image_files = files
+            elif image_dir:
+                warnings.append(
+                    f"Image directory not found:\n{image_dir}\n\n"
+                    "Annotations are loaded but images will not display."
+                )
+
+            self._project_io.apply_project_to_states(
+                project_data,
+                ds,
+                self._validation_model.state,
+                self._inference_model.state,
+            )
+
+            # Single reset — views see the complete state on first refresh
+            self._dataset_model.beginResetModel()
+            self._dataset_model.endResetModel()
+        finally:
+            self._loading = False
+
+        orphaned = self._orphaned_filenames()
+        if orphaned:
+            sample = sorted(orphaned)[:5]
+            tail = f" and {len(orphaned) - 5} more" if len(orphaned) > 5 else ""
+            warnings.append(
+                f"{len(orphaned)} annotation(s) exist for files not in the image "
+                f"directory ({', '.join(sample)}{tail}). "
+                "They will be dropped on the next save."
+            )
+
+        self._project_dir = str(Path(annoproj_path).parent)
+        self._project_name = project_data.get("project_name", Path(annoproj_path).stem)
+        self._created_at = project_data.get("created_at")
+        self._autosave_manager.set_project_dir(self._project_dir)
+        self.clear_dirty()
+        self.project_opened.emit(self._project_name)
+
+        return project_data, warnings
+
+    def save_project(self) -> str:
+        """Save to the current project directory.
+
+        Returns the absolute path to the written .annoproj file.
+        Raises ValueError if no project directory is set (call save_project_as first).
+        """
+        if not self._project_dir:
+            raise ValueError("No project directory set. Use save_project_as first.")
+        return self._write_project(self._project_dir, self._project_name)
+
+    def save_project_as(self, project_dir: str, project_name: str) -> str:
+        """Save to a new location and update the current project tracking.
+
+        Returns the absolute path to the written .annoproj file.
+        """
+        self._project_dir = project_dir
+        self._project_name = project_name
+        path = self._write_project(project_dir, project_name)
+        self._autosave_manager.set_project_dir(project_dir)
+        return path
+
+    def _write_project(self, project_dir: str, project_name: str) -> str:
+        orphaned = self._orphaned_filenames()
+        if orphaned:
+            logger.warning(
+                "Saving with %d orphaned annotation(s) — they will be dropped: %s",
+                len(orphaned), sorted(orphaned),
+            )
+
+        path = self._project_io.save_project(
+            project_dir=project_dir,
+            project_name=project_name,
+            dataset_state=self._dataset_model.state,
+            validation_state=self._validation_model.state,
+            inference_state=self._inference_model.state,
+            created_at=self._created_at,
+            save_score_maps=True,
+            model_path=self._inference_controller.get_model_path()
+            if self._inference_controller
+            else "",
+        )
+        if self._created_at is None:
+            self._created_at = datetime.now(timezone.utc).isoformat()
+        self.clear_dirty()
+        self.project_saved.emit(path)
+        return path
+
+    # ------------------------------------------------------------------ #
+    # Autosave
+    # ------------------------------------------------------------------ #
+
+    def _do_autosave(self, project_dir: str) -> None:
+        """Write an autosave snapshot. Skips NPZ to keep the write fast."""
+        if not self._is_dirty:
+            return
+        autosave_dir = os.path.join(project_dir, "autosave")
+        try:
+            path = self._project_io.save_project(
+                project_dir=autosave_dir,
+                project_name=f"{self._project_name}.autosave",
+                dataset_state=self._dataset_model.state,
+                validation_state=self._validation_model.state,
+                inference_state=self._inference_model.state,
+                created_at=self._created_at,
+                save_score_maps=False,
+                model_path=self._inference_controller.get_model_path()
+                if self._inference_controller
+                else "",
+            )
+            self.autosave_written.emit(path)
+        except Exception as exc:
+            self.autosave_failed.emit(str(exc))
+
+    # ------------------------------------------------------------------ #
+    # Relocate images
+    # ------------------------------------------------------------------ #
+
+    def relocate_images(self, new_dir: str) -> None:
+        """Point to a new image directory without clearing annotations.
+
+        Updates image_dir and image_files in state, then emits a model
+        reset so views refresh. Annotations are preserved — only the
+        images list changes. Files in the new directory that don't have
+        annotations will appear with none; annotations for filenames not
+        present in the new directory become orphaned.
+
+        Args:
+            new_dir: Absolute path to the new image directory.
+
+        Raises:
+            OSError: If new_dir cannot be listed.
+        """
+        files = sorted(
+            f for f in os.listdir(new_dir)
+            if Path(f).suffix.lower() in _IMAGE_EXTENSIONS
+        )
+        state = self._dataset_model.state
+        state.image_dir = new_dir
+        state.image_files = files
+
+        self._loading = True
+        try:
+            self._dataset_model.beginResetModel()
+            self._dataset_model.endResetModel()
+        finally:
+            self._loading = False
+
+        self.mark_dirty()
+
+    # ------------------------------------------------------------------ #
+    # COCO standalone export
+    # ------------------------------------------------------------------ #
+
+    def export_coco(self, coco_path: str) -> None:
+        """Export current annotations as a standalone COCO JSON file."""
+        self._project_io.export_coco(coco_path, self._dataset_model.state)
+
+    # ------------------------------------------------------------------ #
+    # Orphaned annotation detection
+    # ------------------------------------------------------------------ #
+
+    def orphaned_annotations_warning(self) -> str:
+        """Return a user-facing warning string if orphaned annotations exist.
+
+        Orphaned annotations are those keyed to filenames not present in the
+        current image_files list. They survive in state but are silently
+        dropped from the COCO file on the next save.
+        """
+        orphaned = self._orphaned_filenames()
+        if not orphaned:
+            return ""
+        sample = sorted(orphaned)[:5]
+        tail = f" and {len(orphaned) - 5} more" if len(orphaned) > 5 else ""
+        return (
+            f"{len(orphaned)} annotation(s) exist for files not in the current "
+            f"image directory ({', '.join(sample)}{tail}). "
+            "These will be permanently dropped on save. Continue?"
+        )
+
+    def _orphaned_filenames(self) -> List[str]:
+        state = self._dataset_model.state
+        image_set = set(state.image_files)
+        return [f for f in state.annotations if f not in image_set]

--- a/src/core/autosave.py
+++ b/src/core/autosave.py
@@ -1,0 +1,88 @@
+"""
+AutosaveManager — QTimer-based autosave signal emitter.
+
+Emits save_requested with the current project directory when the timer
+fires. The actual write is handled by an AppWindow slot so that Qt
+threading rules are respected (everything on the main thread, no locking
+needed because Qt timers cannot interleave with slots in the same thread).
+"""
+
+import logging
+
+from PySide6.QtCore import QObject, QTimer, Signal
+
+logger = logging.getLogger("AnnoMate.AutosaveManager")
+
+_DEFAULT_INTERVAL_MINUTES = 5
+
+
+class AutosaveManager(QObject):
+    """Periodic autosave trigger using QTimer.
+
+    Emits save_requested(project_dir) on each timer tick. The connected
+    slot (in AppWindow) performs the actual disk write. The timer only runs
+    when a project directory has been set via set_project_dir().
+
+    Signals:
+        save_requested (str): Emitted with the project directory path when
+            the timer fires and a project is open.
+    """
+
+    save_requested = Signal(str)
+
+    def __init__(self, interval_minutes: int = _DEFAULT_INTERVAL_MINUTES, parent: QObject = None) -> None:
+        super().__init__(parent)
+        self._project_dir: str = ""
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._on_timer)
+        self.set_interval(interval_minutes)
+
+    def set_project_dir(self, project_dir: str) -> None:
+        """Set the current project directory and start the timer if not running.
+
+        Passing an empty string stops the timer.
+
+        Args:
+            project_dir: Absolute path to the project directory.
+        """
+        self._project_dir = project_dir
+        if project_dir:
+            if not self._timer.isActive():
+                self._timer.start()
+                logger.debug("Autosave timer started (%d ms).", self._timer.interval())
+        else:
+            self.stop()
+
+    def set_interval(self, minutes: int) -> None:
+        """Update the autosave interval in minutes.
+
+        Takes effect immediately if the timer is currently active.
+
+        Args:
+            minutes: Interval in minutes (must be >= 1).
+        """
+        ms = max(1, minutes) * 60 * 1000
+        was_active = self._timer.isActive()
+        self._timer.setInterval(ms)
+        if was_active:
+            self._timer.start()  # restart with new interval
+
+    def start(self) -> None:
+        """Start (or restart) the autosave timer."""
+        if self._project_dir:
+            self._timer.start()
+            logger.debug("Autosave timer started.")
+
+    def stop(self) -> None:
+        """Stop the autosave timer."""
+        self._timer.stop()
+        logger.debug("Autosave timer stopped.")
+
+    def is_active(self) -> bool:
+        """Return True if the timer is currently running."""
+        return self._timer.isActive()
+
+    def _on_timer(self) -> None:
+        if self._project_dir:
+            logger.debug("Autosave tick — emitting save_requested for: %s", self._project_dir)
+            self.save_requested.emit(self._project_dir)

--- a/src/core/persistence/autosave.py
+++ b/src/core/persistence/autosave.py
@@ -2,9 +2,8 @@
 AutosaveManager — QTimer-based autosave signal emitter.
 
 Emits save_requested with the current project directory when the timer
-fires. The actual write is handled by an AppWindow slot so that Qt
-threading rules are respected (everything on the main thread, no locking
-needed because Qt timers cannot interleave with slots in the same thread).
+fires. The actual write is handled by a ProjectController slot so that
+Qt threading rules are respected (everything on the main thread).
 """
 
 import logging
@@ -20,8 +19,8 @@ class AutosaveManager(QObject):
     """Periodic autosave trigger using QTimer.
 
     Emits save_requested(project_dir) on each timer tick. The connected
-    slot (in AppWindow) performs the actual disk write. The timer only runs
-    when a project directory has been set via set_project_dir().
+    slot performs the actual disk write. The timer only runs when a project
+    directory has been set via set_project_dir().
 
     Signals:
         save_requested (str): Emitted with the project directory path when
@@ -30,7 +29,11 @@ class AutosaveManager(QObject):
 
     save_requested = Signal(str)
 
-    def __init__(self, interval_minutes: int = _DEFAULT_INTERVAL_MINUTES, parent: QObject = None) -> None:
+    def __init__(
+        self,
+        interval_minutes: int = _DEFAULT_INTERVAL_MINUTES,
+        parent: QObject = None,
+    ) -> None:
         super().__init__(parent)
         self._project_dir: str = ""
         self._timer = QTimer(self)
@@ -41,9 +44,6 @@ class AutosaveManager(QObject):
         """Set the current project directory and start the timer if not running.
 
         Passing an empty string stops the timer.
-
-        Args:
-            project_dir: Absolute path to the project directory.
         """
         self._project_dir = project_dir
         if project_dir:
@@ -54,29 +54,21 @@ class AutosaveManager(QObject):
             self.stop()
 
     def set_interval(self, minutes: int) -> None:
-        """Update the autosave interval in minutes.
-
-        Takes effect immediately if the timer is currently active.
-
-        Args:
-            minutes: Interval in minutes (must be >= 1).
-        """
+        """Update the autosave interval in minutes. Takes effect immediately."""
         ms = max(1, minutes) * 60 * 1000
         was_active = self._timer.isActive()
         self._timer.setInterval(ms)
         if was_active:
-            self._timer.start()  # restart with new interval
+            self._timer.start()
 
     def start(self) -> None:
         """Start (or restart) the autosave timer."""
         if self._project_dir:
             self._timer.start()
-            logger.debug("Autosave timer started.")
 
     def stop(self) -> None:
         """Stop the autosave timer."""
         self._timer.stop()
-        logger.debug("Autosave timer stopped.")
 
     def is_active(self) -> bool:
         """Return True if the timer is currently running."""
@@ -84,5 +76,5 @@ class AutosaveManager(QObject):
 
     def _on_timer(self) -> None:
         if self._project_dir:
-            logger.debug("Autosave tick — emitting save_requested for: %s", self._project_dir)
+            logger.debug("Autosave tick — emitting save_requested.")
             self.save_requested.emit(self._project_dir)

--- a/src/core/persistence/project_io.py
+++ b/src/core/persistence/project_io.py
@@ -51,6 +51,7 @@ class ProjectIO:
         inference_state,
         created_at: Optional[str] = None,
         save_score_maps: bool = True,
+        model_path: str = "",
     ) -> str:
         """Write .annoproj + annotations.coco.json to project_dir.
 
@@ -66,6 +67,7 @@ class ProjectIO:
             inference_state: InferenceState instance.
             created_at: ISO timestamp from the original save; if None, uses now.
             save_score_maps: When True, write inference score maps to NPZ.
+            model_path: Absolute path to the inference model file (informational).
         """
         project_dir = str(Path(project_dir).resolve())
         os.makedirs(project_dir, exist_ok=True)
@@ -126,6 +128,7 @@ class ProjectIO:
             "inference": {
                 "score_cache": dict(inference_state.inference_cache),
                 "score_maps_file": score_maps_file,
+                "model_path": model_path,
             },
         }
 
@@ -180,10 +183,11 @@ class ProjectIO:
     ) -> None:
         """Mutate the three state objects from load_project() output.
 
-        Assumes load_folder() has already been called on the dataset so that
-        image_files is populated and per-image state has been cleared. This
-        method then repopulates annotations, class registry, inspectors, notes,
-        validation paths, and inference cache on top of that cleared state.
+        Does NOT touch image_dir or image_files — those must be set by the
+        caller before invoking this method (e.g. via ProjectController which
+        scans the directory first). This method repopulates annotations,
+        class registry, inspectors, notes, validation paths, and inference
+        cache on top of whatever image list is already in state.
 
         Args:
             project_data: Dict returned by load_project().
@@ -276,13 +280,11 @@ class ProjectIO:
             "annotations": [],
         }
 
-        # categories: one entry per class in registry order
         cat_id_map = {}
         for i, name in enumerate(dataset_state.class_names, start=1):
             coco["categories"].append({"id": i, "name": name, "supercategory": ""})
             cat_id_map[name] = i
 
-        # images + annotations
         ann_id = 1
         for img_id, fname in enumerate(dataset_state.image_files, start=1):
             img_path = (
@@ -300,7 +302,6 @@ class ProjectIO:
                 cat_name = ann_rec["category_name"]
                 cat_id = cat_id_map.get(cat_name)
                 if cat_id is None:
-                    # category added after class_names was serialised — register it
                     cat_id = len(coco["categories"]) + 1
                     coco["categories"].append(
                         {"id": cat_id, "name": cat_name, "supercategory": ""}
@@ -395,17 +396,13 @@ class ProjectIO:
         """Return (width, height) via PIL. Returns (0, 0) if file is missing."""
         try:
             with Image.open(image_path) as img:
-                return img.size  # (width, height)
+                return img.size
         except Exception:
             logger.debug("Could not read dimensions for: %s", image_path)
             return (0, 0)
 
     def _resolve_coco_path(self, annoproj_path: str, proj_data: dict) -> str:
-        """Resolve the COCO JSON path from project data.
-
-        Tries annotations_file_abs first; falls back to resolving
-        annotations_file relative to the project directory.
-        """
+        """Resolve the COCO JSON path: try absolute first, then relative."""
         abs_path = proj_data.get("annotations_file_abs", "")
         if abs_path and os.path.exists(abs_path):
             return abs_path
@@ -416,8 +413,18 @@ class ProjectIO:
 
     def _filename_to_npz_key(self, fname: str) -> str:
         """Sanitize a filename to a valid NPZ array key."""
-        return fname.replace(".", "__dot__").replace("/", "__slash__").replace("\\", "__bslash__")
+        return (
+            fname
+            .replace(".", "__dot__")
+            .replace("/", "__slash__")
+            .replace("\\", "__bslash__")
+        )
 
     def _npz_key_to_filename(self, key: str) -> str:
         """Reverse _filename_to_npz_key."""
-        return key.replace("__bslash__", "\\").replace("__slash__", "/").replace("__dot__", ".")
+        return (
+            key
+            .replace("__bslash__", "\\")
+            .replace("__slash__", "/")
+            .replace("__dot__", ".")
+        )

--- a/src/core/project_io.py
+++ b/src/core/project_io.py
@@ -1,0 +1,423 @@
+"""
+ProjectIO — headless save/load for .annoproj project files.
+
+No Qt dependencies. Accepts state objects and plain paths. Separates
+load_project (disk read) from apply_project_to_states (state mutation)
+so callers can inspect data before applying it.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from PIL import Image
+
+from core.utils.constants import DEFAULT_CLASS_COLORS
+from core.utils.geometry import polygon_area, polygon_bbox
+
+logger = logging.getLogger("AnnoMate.ProjectIO")
+
+_SCHEMA_VERSION = "1.0"
+_COCO_FILENAME = "annotations.coco.json"
+_SCOREMAPS_FILENAME = "scoremaps.npz"
+
+
+class ProjectIO:
+    """Headless save/load for .annoproj project files.
+
+    All methods accept plain Python values. No Qt dependencies. Raises
+    standard exceptions (OSError, json.JSONDecodeError, KeyError) on failure;
+    callers are responsible for user-facing error display.
+    """
+
+    SCHEMA_VERSION = _SCHEMA_VERSION
+    COCO_FILENAME = _COCO_FILENAME
+    SCOREMAPS_FILENAME = _SCOREMAPS_FILENAME
+
+    # ------------------------------------------------------------------ #
+    # Save
+    # ------------------------------------------------------------------ #
+
+    def save_project(
+        self,
+        project_dir: str,
+        project_name: str,
+        dataset_state,
+        validation_state,
+        inference_state,
+        created_at: Optional[str] = None,
+        save_score_maps: bool = True,
+    ) -> str:
+        """Write .annoproj + annotations.coco.json to project_dir.
+
+        Creates project_dir if it does not exist. Returns the absolute path
+        to the written .annoproj file. Raises OSError if the directory cannot
+        be created or any file cannot be written.
+
+        Args:
+            project_dir: Directory that will contain all project files.
+            project_name: Human-readable project name (used as filename stem).
+            dataset_state: DatasetState instance.
+            validation_state: ValidationState instance.
+            inference_state: InferenceState instance.
+            created_at: ISO timestamp from the original save; if None, uses now.
+            save_score_maps: When True, write inference score maps to NPZ.
+        """
+        project_dir = str(Path(project_dir).resolve())
+        os.makedirs(project_dir, exist_ok=True)
+
+        now = datetime.now(timezone.utc).isoformat()
+        if created_at is None:
+            created_at = now
+
+        coco_path = os.path.join(project_dir, _COCO_FILENAME)
+        self.export_coco(coco_path, dataset_state)
+
+        score_maps_file = ""
+        if save_score_maps and inference_state.score_maps:
+            npz_path = os.path.join(project_dir, _SCOREMAPS_FILENAME)
+            try:
+                np.savez_compressed(
+                    npz_path,
+                    **{
+                        self._filename_to_npz_key(f): arr
+                        for f, arr in inference_state.score_maps.items()
+                    },
+                )
+                score_maps_file = _SCOREMAPS_FILENAME
+            except Exception as exc:
+                logger.warning("Could not save score maps: %s", exc)
+
+        review_status = {}
+        for fname in dataset_state.image_files:
+            inspector = dataset_state.inspectors.get(fname, "")
+            note = dataset_state.notes.get(fname, "")
+            if inspector or note:
+                review_status[fname] = {"inspector": inspector, "note": note}
+
+        proj = {
+            "version": _SCHEMA_VERSION,
+            "created_at": created_at,
+            "modified_at": now,
+            "project_name": project_name,
+            "dataset": {
+                "image_dir": dataset_state.image_dir or "",
+                "class_names": list(dataset_state.class_names),
+                "class_colors": {
+                    name: list(rgb)
+                    for name, rgb in dataset_state.class_colors.items()
+                },
+            },
+            "annotations_file": _COCO_FILENAME,
+            "annotations_file_abs": coco_path,
+            "validation": {
+                "poly_path": validation_state.poly_path,
+                "json_path": validation_state.json_path,
+                "mask_out_path": validation_state.mask_out_path,
+                "gt_path": validation_state.gt_path,
+                "pred_path": validation_state.pred_path,
+                "eval_out_path": validation_state.eval_out_path,
+            },
+            "review_status": review_status,
+            "inference": {
+                "score_cache": dict(inference_state.inference_cache),
+                "score_maps_file": score_maps_file,
+            },
+        }
+
+        annoproj_path = os.path.join(project_dir, f"{project_name}.annoproj")
+        with open(annoproj_path, "w", encoding="utf-8") as f:
+            json.dump(proj, f, indent=2)
+
+        logger.debug("Project saved to: %s", annoproj_path)
+        return annoproj_path
+
+    # ------------------------------------------------------------------ #
+    # Load
+    # ------------------------------------------------------------------ #
+
+    def load_project(self, annoproj_path: str) -> dict:
+        """Read a .annoproj file and return its parsed data.
+
+        Does NOT mutate any state objects. Call apply_project_to_states()
+        after this to apply the data. Resolves the COCO annotations path
+        and adds a 'resolved_coco_path' key to the returned dict.
+
+        Args:
+            annoproj_path: Absolute path to the .annoproj file.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            json.JSONDecodeError: If the file is not valid JSON.
+        """
+        annoproj_path = str(Path(annoproj_path).resolve())
+        with open(annoproj_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        data["_annoproj_path"] = annoproj_path
+        data["resolved_coco_path"] = self._resolve_coco_path(annoproj_path, data)
+
+        npz_file = data.get("inference", {}).get("score_maps_file", "")
+        if npz_file:
+            proj_dir = str(Path(annoproj_path).parent)
+            abs_npz = os.path.join(proj_dir, npz_file)
+            data["_resolved_npz_path"] = abs_npz if os.path.exists(abs_npz) else ""
+        else:
+            data["_resolved_npz_path"] = ""
+
+        return data
+
+    def apply_project_to_states(
+        self,
+        project_data: dict,
+        dataset_state,
+        validation_state,
+        inference_state,
+    ) -> None:
+        """Mutate the three state objects from load_project() output.
+
+        Assumes load_folder() has already been called on the dataset so that
+        image_files is populated and per-image state has been cleared. This
+        method then repopulates annotations, class registry, inspectors, notes,
+        validation paths, and inference cache on top of that cleared state.
+
+        Args:
+            project_data: Dict returned by load_project().
+            dataset_state: DatasetState to populate.
+            validation_state: ValidationState to populate.
+            inference_state: InferenceState to populate.
+        """
+        ds = project_data.get("dataset", {})
+
+        # Class registry
+        class_names = ds.get("class_names", [])
+        if class_names:
+            dataset_state.class_names = list(class_names)
+            raw_colors = ds.get("class_colors", {})
+            dataset_state.class_colors = {}
+            for i, name in enumerate(dataset_state.class_names):
+                raw = raw_colors.get(name)
+                if isinstance(raw, (list, tuple)) and len(raw) == 3:
+                    dataset_state.class_colors[name] = (
+                        int(raw[0]), int(raw[1]), int(raw[2])
+                    )
+                else:
+                    dataset_state.class_colors[name] = DEFAULT_CLASS_COLORS[
+                        i % len(DEFAULT_CLASS_COLORS)
+                    ]
+
+        # Annotations from COCO file
+        coco_path = project_data.get("resolved_coco_path", "")
+        if coco_path and os.path.exists(coco_path):
+            try:
+                self.import_coco(coco_path, dataset_state)
+            except Exception as exc:
+                logger.warning("Could not load COCO annotations: %s", exc)
+
+        # Review status (inspector / note)
+        for fname, info in project_data.get("review_status", {}).items():
+            dataset_state.inspectors[fname] = info.get("inspector", "")
+            dataset_state.notes[fname] = info.get("note", "")
+
+        # Validation paths
+        vdata = project_data.get("validation", {})
+        validation_state.poly_path = vdata.get("poly_path", "")
+        validation_state.json_path = vdata.get("json_path", "")
+        validation_state.mask_out_path = vdata.get("mask_out_path", "")
+        validation_state.gt_path = vdata.get("gt_path", "")
+        validation_state.pred_path = vdata.get("pred_path", "")
+        validation_state.eval_out_path = vdata.get("eval_out_path", "")
+
+        # Inference cache (float scores only — fast to restore)
+        inf_data = project_data.get("inference", {})
+        inference_state.inference_cache = dict(inf_data.get("score_cache", {}))
+
+        # Score maps from NPZ (optional)
+        npz_path = project_data.get("_resolved_npz_path", "")
+        if npz_path and os.path.exists(npz_path):
+            try:
+                npz = np.load(npz_path)
+                for key in npz.files:
+                    fname = self._npz_key_to_filename(key)
+                    inference_state.score_maps[fname] = npz[key]
+            except Exception as exc:
+                logger.warning("Could not load score maps from NPZ: %s", exc)
+
+    # ------------------------------------------------------------------ #
+    # COCO export / import
+    # ------------------------------------------------------------------ #
+
+    def export_coco(self, coco_path: str, dataset_state) -> None:
+        """Write a standard COCO Instance Segmentation JSON to coco_path.
+
+        Reads image dimensions from disk via PIL. Missing images produce
+        width=0, height=0 entries (valid COCO sentinel). Only images that
+        have at least one annotation are included in the annotations array;
+        all loaded images appear in the images array.
+
+        Args:
+            coco_path: Absolute path for the output JSON file.
+            dataset_state: DatasetState whose annotations are exported.
+        """
+        now_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        coco = {
+            "info": {
+                "description": "AnnoMate export",
+                "version": _SCHEMA_VERSION,
+                "date_created": now_str,
+            },
+            "licenses": [],
+            "categories": [],
+            "images": [],
+            "annotations": [],
+        }
+
+        # categories: one entry per class in registry order
+        cat_id_map = {}
+        for i, name in enumerate(dataset_state.class_names, start=1):
+            coco["categories"].append({"id": i, "name": name, "supercategory": ""})
+            cat_id_map[name] = i
+
+        # images + annotations
+        ann_id = 1
+        for img_id, fname in enumerate(dataset_state.image_files, start=1):
+            img_path = (
+                os.path.join(dataset_state.image_dir, fname)
+                if dataset_state.image_dir
+                else fname
+            )
+            w, h = self._read_image_size(img_path)
+            coco["images"].append(
+                {"id": img_id, "file_name": fname, "width": w, "height": h}
+            )
+
+            for ann_rec in dataset_state.annotations.get(fname, []):
+                polygon = ann_rec["polygon"]
+                cat_name = ann_rec["category_name"]
+                cat_id = cat_id_map.get(cat_name)
+                if cat_id is None:
+                    # category added after class_names was serialised — register it
+                    cat_id = len(coco["categories"]) + 1
+                    coco["categories"].append(
+                        {"id": cat_id, "name": cat_name, "supercategory": ""}
+                    )
+                    cat_id_map[cat_name] = cat_id
+
+                coco["annotations"].append(
+                    self._build_coco_annotation(ann_id, img_id, cat_id, polygon)
+                )
+                ann_id += 1
+
+        os.makedirs(str(Path(coco_path).parent), exist_ok=True)
+        with open(coco_path, "w", encoding="utf-8") as f:
+            json.dump(coco, f, indent=2)
+
+        logger.debug("COCO JSON written to: %s (%d annotations)", coco_path, ann_id - 1)
+
+    def import_coco(self, coco_path: str, dataset_state) -> None:
+        """Read a COCO JSON file into dataset_state (annotations + classes).
+
+        Does NOT clear existing data — merges on top of whatever is already
+        in state. Callers should clear state if a full replacement is needed.
+        Follows the same logic as IOController._import_coco_format.
+
+        Args:
+            coco_path: Absolute path to the COCO JSON file.
+            dataset_state: DatasetState to populate.
+        """
+        with open(coco_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        cat_map = {}
+        for c in data.get("categories", []):
+            name = c["name"]
+            cat_map[c["id"]] = name
+            if name not in dataset_state.class_names:
+                idx = len(dataset_state.class_names)
+                dataset_state.class_names.append(name)
+                dataset_state.class_colors[name] = DEFAULT_CLASS_COLORS[
+                    idx % len(DEFAULT_CLASS_COLORS)
+                ]
+
+        img_id_map = {img["id"]: img["file_name"] for img in data.get("images", [])}
+
+        for ann in data.get("annotations", []):
+            img_id = ann["image_id"]
+            if img_id not in img_id_map:
+                continue
+            filename = img_id_map[img_id]
+            cat_name = cat_map.get(ann["category_id"], "Unknown")
+            seg = ann.get("segmentation", [])
+            polygon = self._coco_seg_to_poly(seg)
+            if polygon:
+                dataset_state.annotations.setdefault(filename, []).append(
+                    {"category_name": cat_name, "polygon": polygon}
+                )
+
+    # ------------------------------------------------------------------ #
+    # Private helpers
+    # ------------------------------------------------------------------ #
+
+    def _poly_to_coco_seg(self, polygon: list) -> list:
+        """Convert [(x,y), ...] to COCO segmentation [[x0,y0,x1,y1,...]]."""
+        flat = [coord for pt in polygon for coord in (float(pt[0]), float(pt[1]))]
+        return [flat]
+
+    def _coco_seg_to_poly(self, segmentation: list) -> list:
+        """Convert COCO segmentation [[x0,y0,...]] to [(x,y), ...]."""
+        if not isinstance(segmentation, list) or not segmentation:
+            return []
+        pts_list = segmentation[0] if isinstance(segmentation[0], list) else segmentation
+        poly = []
+        for i in range(0, len(pts_list) - 1, 2):
+            poly.append((float(pts_list[i]), float(pts_list[i + 1])))
+        return poly
+
+    def _build_coco_annotation(
+        self, ann_id: int, image_id: int, category_id: int, polygon: list
+    ) -> dict:
+        """Build a single COCO annotation dict with area, bbox, segmentation."""
+        return {
+            "id": ann_id,
+            "image_id": image_id,
+            "category_id": category_id,
+            "segmentation": self._poly_to_coco_seg(polygon),
+            "area": float(polygon_area(polygon)),
+            "bbox": [float(v) for v in polygon_bbox(polygon)],
+            "iscrowd": 0,
+        }
+
+    def _read_image_size(self, image_path: str) -> tuple:
+        """Return (width, height) via PIL. Returns (0, 0) if file is missing."""
+        try:
+            with Image.open(image_path) as img:
+                return img.size  # (width, height)
+        except Exception:
+            logger.debug("Could not read dimensions for: %s", image_path)
+            return (0, 0)
+
+    def _resolve_coco_path(self, annoproj_path: str, proj_data: dict) -> str:
+        """Resolve the COCO JSON path from project data.
+
+        Tries annotations_file_abs first; falls back to resolving
+        annotations_file relative to the project directory.
+        """
+        abs_path = proj_data.get("annotations_file_abs", "")
+        if abs_path and os.path.exists(abs_path):
+            return abs_path
+
+        rel_file = proj_data.get("annotations_file", _COCO_FILENAME)
+        proj_dir = str(Path(annoproj_path).parent)
+        return os.path.join(proj_dir, rel_file)
+
+    def _filename_to_npz_key(self, fname: str) -> str:
+        """Sanitize a filename to a valid NPZ array key."""
+        return fname.replace(".", "__dot__").replace("/", "__slash__").replace("\\", "__bslash__")
+
+    def _npz_key_to_filename(self, key: str) -> str:
+        """Reverse _filename_to_npz_key."""
+        return key.replace("__bslash__", "\\").replace("__slash__", "/").replace("__dot__", ".")

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,13 @@
-import os
+"""
+Entry point — composition root only.
+
+Creates all layers in dependency order (states → models → controllers → view)
+and starts the Qt event loop. Contains no UI code.
+"""
+
 import sys
 
-from PySide6.QtWidgets import (
-    QApplication, QMainWindow, QTabWidget, QVBoxLayout, QWidget, QInputDialog,
-    QFileDialog, QMessageBox,
-)
-from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtWidgets import QApplication
 
 from core.utils.logger import setup_logging
 setup_logging()
@@ -13,6 +15,7 @@ setup_logging()
 from core.states.dataset_state import DatasetState
 from core.states.inference_state import InferenceState
 from core.states.validation_state import ValidationState
+
 from models.dataset_model import DatasetTableModel
 from models.inference_model import InferenceModel
 from models.validation_model import ValidationModel
@@ -22,324 +25,47 @@ from controllers.inference_controller import InferenceController
 from controllers.validation_controller import ValidationController
 from controllers.project_controller import ProjectController
 
-from views.annomate.window import ImageAnnotator
-from views.microsentry.window import MicroSentryWindow
-from views.validation.window import ValidationWindow
-
-_APP_TITLE = "AnnoMate & MicroSentryAI"
+from views.app_window import AppWindow
 
 
-class AppWindow(QMainWindow):
-    def __init__(self):
-        super().__init__()
-        self.setWindowTitle(_APP_TITLE)
-        self.resize(1400, 900)
-
-        # Domain state
-        self.dataset_state    = DatasetState()
-        self.inference_state  = InferenceState()
-        self.validation_state = ValidationState()
-
-        # Models
-        self.dataset_model    = DatasetTableModel(self.dataset_state)
-        self.inference_model  = InferenceModel(self.inference_state)
-        self.validation_model = ValidationModel(self.validation_state)
-
-        # Controllers
-        self.io_controller         = IOController(self.dataset_model)
-        self.inference_controller  = InferenceController(
-            self.dataset_model, self.inference_model
-        )
-        self.validation_controller = ValidationController(self.validation_model)
-        self.project_controller    = ProjectController(
-            self.dataset_model,
-            self.inference_model,
-            self.validation_model,
-            self.io_controller,
-            self.inference_controller,
-            parent=self,
-        )
-
-        # Views
-        self.annomate_view   = ImageAnnotator(self.dataset_model, self.io_controller)
-        self.sentry_view     = MicroSentryWindow(
-            self.dataset_model,
-            self.inference_model,
-            self.inference_controller,
-            self.io_controller,
-        )
-        self.validation_view = ValidationWindow(
-            self.validation_model, self.validation_controller
-        )
-
-        # Cross-tab row sync
-        self.annomate_view.row_selection_changed.connect(self.sentry_view.select_row)
-        self.sentry_view.row_selection_changed.connect(self.annomate_view.select_row)
-
-        # Polygon transfer: MicroSentry → AnnoMate
-        self.sentry_view.polygonsSent.connect(self._handle_polygon_transfer)
-
-        self.tabs = QTabWidget()
-        self.tabs.addTab(self.annomate_view,   "AnnoMate")
-        self.tabs.addTab(self.sentry_view,     "MicroSentry AI")
-        self.tabs.addTab(self.validation_view, "Validation")
-
-        central_widget = QWidget()
-        layout = QVBoxLayout(central_widget)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.tabs)
-        self.setCentralWidget(central_widget)
-
-        # ProjectController owns dirty tracking; AppWindow just reacts
-        self.project_controller.dirty_changed.connect(self._update_title)
-        self.project_controller.project_saved.connect(
-            lambda path: self.statusBar().showMessage(f"Saved: {path}", 4000)
-        )
-        self.project_controller.autosave_written.connect(
-            lambda _: self.statusBar().showMessage("Autosaved", 3000)
-        )
-        self.project_controller.autosave_failed.connect(
-            lambda msg: self.statusBar().showMessage(f"Autosave failed: {msg}", 5000)
-        )
-
-        self._build_menu()
-
-    # ================================================================== #
-    # Menu bar
-    # ================================================================== #
-
-    def _build_menu(self) -> None:
-        file_menu = self.menuBar().addMenu("&File")
-
-        def add(label, shortcut, slot):
-            act = QAction(label, self)
-            if shortcut:
-                act.setShortcut(QKeySequence(shortcut))
-            act.triggered.connect(slot)
-            file_menu.addAction(act)
-            return act
-
-        add("New Project",        "Ctrl+N",       self._new_project)
-        add("Open Project…",      "Ctrl+O",       self._open_project)
-        add("Save Project",       "Ctrl+S",       self._save_project)
-        add("Save Project As…",   "Ctrl+Shift+S", self._save_project_as)
-        file_menu.addSeparator()
-        add("Relocate Images…",   "",             self._relocate_images)
-        file_menu.addSeparator()
-        add("Export COCO JSON…",  "",             self._export_coco)
-        add("Import COCO JSON…",  "",             self._import_coco)
-        file_menu.addSeparator()
-        add("Exit",               "Ctrl+Q",       self.close)
-
-    # ================================================================== #
-    # Project slots
-    # ================================================================== #
-
-    def _new_project(self) -> None:
-        if self.project_controller.is_dirty and not self._confirm_discard():
-            return
-        self.project_controller.new_project()
-
-    def _open_project(self) -> None:
-        if self.project_controller.is_dirty and not self._confirm_discard():
-            return
-
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Open Project", os.getcwd(), "AnnoMate Project (*.annoproj)"
-        )
-        if not path:
-            return
-
-        try:
-            project_data, warnings = self.project_controller.open_project(path)
-        except Exception as exc:
-            QMessageBox.critical(self, "Open Project", f"Could not read project:\n{exc}")
-            return
-
-        self.annomate_view.refresh_class_combo()
-
-        if warnings:
-            QMessageBox.warning(self, "Open Project", "\n\n".join(warnings))
-
-        # Surface the previously-used model path (informational)
-        model_path = project_data.get("inference", {}).get("model_path", "")
-        if model_path and not self.inference_controller.has_model():
-            self.statusBar().showMessage(
-                f"Previous model: {model_path} — reload it in MicroSentry AI if needed.",
-                8000,
-            )
-
-    def _save_project(self) -> None:
-        if not self.project_controller.has_project:
-            self._save_project_as()
-            return
-        self._check_orphans_then_save(self.project_controller.save_project)
-
-    def _save_project_as(self) -> None:
-        parent_dir = QFileDialog.getExistingDirectory(
-            self, "Choose Project Folder", os.getcwd()
-        )
-        if not parent_dir:
-            return
-
-        from pathlib import Path
-        default_name = (
-            Path(self.dataset_state.image_dir).name
-            if self.dataset_state.image_dir
-            else "project"
-        )
-        name, ok = QInputDialog.getText(
-            self, "Project Name", "Enter project name:", text=default_name
-        )
-        if not ok or not name.strip():
-            return
-
-        name = name.strip()
-        project_dir = os.path.join(parent_dir, name)
-        self._check_orphans_then_save(
-            lambda: self.project_controller.save_project_as(project_dir, name)
-        )
-
-    def _check_orphans_then_save(self, save_fn) -> None:
-        """Show orphaned-annotation warning if needed, then call save_fn."""
-        warning = self.project_controller.orphaned_annotations_warning()
-        if warning:
-            reply = QMessageBox.warning(
-                self, "Orphaned Annotations", warning,
-                QMessageBox.Ok | QMessageBox.Cancel,
-                QMessageBox.Cancel,
-            )
-            if reply != QMessageBox.Ok:
-                return
-        try:
-            save_fn()
-        except Exception as exc:
-            QMessageBox.critical(self, "Save Project", f"Could not save:\n{exc}")
-
-    def _relocate_images(self) -> None:
-        """Point to a new image directory without clearing annotations."""
-        new_dir = QFileDialog.getExistingDirectory(
-            self, "Select New Image Folder", os.getcwd()
-        )
-        if not new_dir:
-            return
-        try:
-            self.project_controller.relocate_images(new_dir)
-        except Exception as exc:
-            QMessageBox.critical(self, "Relocate Images", f"Could not scan folder:\n{exc}")
-            return
-        self.annomate_view.refresh_class_combo()
-
-        orphan_msg = self.project_controller.orphaned_annotations_warning()
-        if orphan_msg:
-            QMessageBox.information(
-                self, "Annotations After Relocation",
-                orphan_msg.replace("Continue?", "They will be dropped on the next save.")
-            )
-
-    # ================================================================== #
-    # COCO export / import
-    # ================================================================== #
-
-    def _export_coco(self) -> None:
-        from pathlib import Path
-        default = (
-            f"{Path(self.dataset_state.image_dir).name}_coco.json"
-            if self.dataset_state.image_dir
-            else "annotations.coco.json"
-        )
-        path, _ = QFileDialog.getSaveFileName(
-            self, "Export COCO JSON", default, "JSON (*.json)"
-        )
-        if not path:
-            return
-        try:
-            self.project_controller.export_coco(path)
-            QMessageBox.information(self, "Export COCO", f"Saved to:\n{path}")
-        except Exception as exc:
-            QMessageBox.critical(self, "Export COCO", f"Export failed:\n{exc}")
-
-    def _import_coco(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Import COCO JSON", "", "JSON (*.json)"
-        )
-        if not path:
-            return
-        try:
-            self.io_controller.import_data_json(path)
-        except Exception as exc:
-            QMessageBox.critical(self, "Import COCO", f"Import failed:\n{exc}")
-            return
-        self.annomate_view.refresh_class_combo()
-
-    # ================================================================== #
-    # Title & close
-    # ================================================================== #
-
-    def _update_title(self, is_dirty: bool = None) -> None:
-        name = self.project_controller.project_name
-        if name:
-            dirty = "*" if self.project_controller.is_dirty else ""
-            self.setWindowTitle(f"{name}{dirty} — {_APP_TITLE}")
-        else:
-            self.setWindowTitle(_APP_TITLE)
-
-    def _confirm_discard(self) -> bool:
-        """Prompt save/discard for unsaved changes. Returns True to proceed."""
-        reply = QMessageBox.question(
-            self, "Unsaved Changes",
-            "You have unsaved changes. Save before continuing?",
-            QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
-            QMessageBox.Save,
-        )
-        if reply == QMessageBox.Save:
-            self._save_project()
-            return True
-        return reply == QMessageBox.Discard
-
-    def closeEvent(self, event) -> None:
-        if self.project_controller.is_dirty:
-            reply = QMessageBox.question(
-                self, "Unsaved Changes",
-                "You have unsaved changes. Save before closing?",
-                QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
-                QMessageBox.Save,
-            )
-            if reply == QMessageBox.Save:
-                self._save_project()
-                event.accept()
-            elif reply == QMessageBox.Discard:
-                event.accept()
-            else:
-                event.ignore()
-                return
-        self.project_controller.autosave_manager.stop()
-        super().closeEvent(event)
-
-    # ================================================================== #
-    # Polygon transfer
-    # ================================================================== #
-
-    def _handle_polygon_transfer(self, polygons: list, default_class: str):
-        class_names = self.dataset_model.get_class_names()
-        if not class_names:
-            class_names = [default_class]
-
-        chosen, ok = QInputDialog.getItem(
-            self, "Choose Class", "Assign polygons to class:",
-            class_names,
-            class_names.index(default_class) if default_class in class_names else 0,
-            False,
-        )
-        if ok and chosen:
-            self.annomate_view.receive_polygons(polygons, chosen)
-
-
-def main():
+def main() -> None:
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
-    window = AppWindow()
+
+    # States
+    dataset_state    = DatasetState()
+    inference_state  = InferenceState()
+    validation_state = ValidationState()
+
+    # Models
+    dataset_model    = DatasetTableModel(dataset_state)
+    inference_model  = InferenceModel(inference_state)
+    validation_model = ValidationModel(validation_state)
+
+    # Controllers
+    io_controller         = IOController(dataset_model)
+    inference_controller  = InferenceController(dataset_model, inference_model)
+    validation_controller = ValidationController(validation_model)
+    project_controller    = ProjectController(
+        dataset_model,
+        inference_model,
+        validation_model,
+        io_controller,
+        inference_controller,
+    )
+
+    # View
+    window = AppWindow(
+        dataset_model=dataset_model,
+        inference_model=inference_model,
+        validation_model=validation_model,
+        io_controller=io_controller,
+        inference_controller=inference_controller,
+        validation_controller=validation_controller,
+        project_controller=project_controller,
+    )
     window.show()
+
     sys.exit(app.exec())
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,14 @@
+import os
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
 from PySide6.QtWidgets import (
     QApplication, QMainWindow, QTabWidget, QVBoxLayout, QWidget, QInputDialog,
+    QFileDialog, QMessageBox,
 )
+from PySide6.QtGui import QAction, QKeySequence
 
 from core.utils.logger import setup_logging
 setup_logging()
@@ -21,11 +28,16 @@ from views.annomate.window import ImageAnnotator
 from views.microsentry.window import MicroSentryWindow
 from views.validation.window import ValidationWindow
 
+from core.project_io import ProjectIO
+from core.autosave import AutosaveManager
+
+_APP_TITLE = "AnnoMate & MicroSentryAI"
+
 
 class AppWindow(QMainWindow):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("AnnoMate & MicroSentryAI (MVC)")
+        self.setWindowTitle(_APP_TITLE)
         self.resize(1400, 900)
 
         # Domain state
@@ -57,7 +69,7 @@ class AppWindow(QMainWindow):
             self.validation_model, self.validation_controller
         )
 
-        # Cross-tab row sync via each view's public API — no access to internal widgets
+        # Cross-tab row sync via each view's public API
         self.annomate_view.row_selection_changed.connect(self.sentry_view.select_row)
         self.sentry_view.row_selection_changed.connect(self.annomate_view.select_row)
 
@@ -74,6 +86,319 @@ class AppWindow(QMainWindow):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.tabs)
         self.setCentralWidget(central_widget)
+
+        # Project state
+        self._project_dir: Optional[str] = None
+        self._project_name: str = ""
+        self._is_dirty: bool = False
+        self._created_at: Optional[str] = None
+
+        # Project I/O helpers
+        self.project_io = ProjectIO()
+        self.autosave_manager = AutosaveManager(interval_minutes=5, parent=self)
+        self.autosave_manager.save_requested.connect(self._do_autosave)
+
+        # Dirty-state tracking
+        self.dataset_model.dataChanged.connect(self._mark_dirty)
+        self.dataset_model.modelReset.connect(self._mark_dirty)
+
+        self._build_menu()
+
+    # ================================================================== #
+    # Menu bar
+    # ================================================================== #
+
+    def _build_menu(self) -> None:
+        """Build the File menu with project and export/import actions."""
+        menu_bar = self.menuBar()
+        file_menu = menu_bar.addMenu("&File")
+
+        act_new = QAction("New Project", self)
+        act_new.setShortcut(QKeySequence("Ctrl+N"))
+        act_new.triggered.connect(self._new_project)
+        file_menu.addAction(act_new)
+
+        act_open = QAction("Open Project…", self)
+        act_open.setShortcut(QKeySequence("Ctrl+O"))
+        act_open.triggered.connect(self._open_project)
+        file_menu.addAction(act_open)
+
+        act_save = QAction("Save Project", self)
+        act_save.setShortcut(QKeySequence("Ctrl+S"))
+        act_save.triggered.connect(self._save_project)
+        file_menu.addAction(act_save)
+
+        act_save_as = QAction("Save Project As…", self)
+        act_save_as.setShortcut(QKeySequence("Ctrl+Shift+S"))
+        act_save_as.triggered.connect(self._save_project_as)
+        file_menu.addAction(act_save_as)
+
+        file_menu.addSeparator()
+
+        act_export_coco = QAction("Export COCO JSON…", self)
+        act_export_coco.triggered.connect(self._export_coco)
+        file_menu.addAction(act_export_coco)
+
+        act_import_coco = QAction("Import COCO JSON…", self)
+        act_import_coco.triggered.connect(self._import_coco)
+        file_menu.addAction(act_import_coco)
+
+        file_menu.addSeparator()
+
+        act_exit = QAction("Exit", self)
+        act_exit.setShortcut(QKeySequence("Ctrl+Q"))
+        act_exit.triggered.connect(self.close)
+        file_menu.addAction(act_exit)
+
+    # ================================================================== #
+    # Project slots
+    # ================================================================== #
+
+    def _new_project(self) -> None:
+        """Prompt to save if dirty, then clear all state and reset project tracking."""
+        if self._is_dirty and not self._confirm_discard():
+            return
+
+        self.dataset_state.clear()
+        self.inference_state.clear()
+        self.validation_state.clear()
+        self.dataset_model.beginResetModel()
+        self.dataset_model.endResetModel()
+
+        self._project_dir = None
+        self._project_name = ""
+        self._created_at = None
+        self.autosave_manager.stop()
+        self._clear_dirty()
+
+    def _open_project(self) -> None:
+        """Open a file dialog to select a .annoproj file, then load the project."""
+        if self._is_dirty and not self._confirm_discard():
+            return
+
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Open Project", os.getcwd(), "AnnoMate Project (*.annoproj)"
+        )
+        if not path:
+            return
+
+        try:
+            project_data = self.project_io.load_project(path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Open Project", f"Could not read project file:\n{exc}")
+            return
+
+        image_dir = project_data.get("dataset", {}).get("image_dir", "")
+        if image_dir and os.path.isdir(image_dir):
+            try:
+                self.io_controller.load_folder(image_dir)
+            except Exception as exc:
+                QMessageBox.warning(
+                    self, "Open Project",
+                    f"Image directory not accessible:\n{image_dir}\n\n{exc}\n\n"
+                    "Annotations will be loaded but images may not display."
+                )
+        elif image_dir:
+            QMessageBox.warning(
+                self, "Open Project",
+                f"Image directory not found:\n{image_dir}\n\n"
+                "Annotations will be loaded but images may not display."
+            )
+
+        try:
+            self.project_io.apply_project_to_states(
+                project_data,
+                self.dataset_state,
+                self.validation_state,
+                self.inference_state,
+            )
+        except Exception as exc:
+            QMessageBox.critical(self, "Open Project", f"Could not apply project data:\n{exc}")
+            return
+
+        # Trigger full view refresh after state is populated
+        self.dataset_model.beginResetModel()
+        self.dataset_model.endResetModel()
+        self.annomate_view.refresh_class_combo()
+
+        self._project_dir = str(Path(path).parent)
+        self._project_name = project_data.get("project_name", Path(path).stem)
+        self._created_at = project_data.get("created_at")
+        self.autosave_manager.set_project_dir(self._project_dir)
+        self._clear_dirty()
+
+    def _save_project(self) -> None:
+        """Save to the current project directory, or prompt for one if not set."""
+        if self._project_dir is None:
+            self._save_project_as()
+            return
+
+        self._write_project(self._project_dir, self._project_name)
+
+    def _save_project_as(self) -> None:
+        """Prompt for a project name and parent directory, then save."""
+        parent_dir = QFileDialog.getExistingDirectory(
+            self, "Choose Project Folder", os.getcwd()
+        )
+        if not parent_dir:
+            return
+
+        default_name = (
+            Path(self.dataset_state.image_dir).name
+            if self.dataset_state.image_dir
+            else "project"
+        )
+        name, ok = QInputDialog.getText(
+            self, "Project Name", "Enter project name:", text=default_name
+        )
+        if not ok or not name.strip():
+            return
+
+        name = name.strip()
+        project_dir = os.path.join(parent_dir, name)
+
+        self._project_dir = project_dir
+        self._project_name = name
+        self._write_project(project_dir, name)
+        self.autosave_manager.set_project_dir(project_dir)
+
+    def _write_project(self, project_dir: str, project_name: str) -> None:
+        """Perform the actual disk write and update dirty/title state."""
+        try:
+            annoproj_path = self.project_io.save_project(
+                project_dir=project_dir,
+                project_name=project_name,
+                dataset_state=self.dataset_state,
+                validation_state=self.validation_state,
+                inference_state=self.inference_state,
+                created_at=self._created_at,
+                save_score_maps=True,
+            )
+        except Exception as exc:
+            QMessageBox.critical(self, "Save Project", f"Could not save project:\n{exc}")
+            return
+
+        if self._created_at is None:
+            self._created_at = datetime.now(timezone.utc).isoformat()
+
+        self._clear_dirty()
+        self.statusBar().showMessage(f"Saved: {annoproj_path}", 4000)
+
+    def _do_autosave(self, project_dir: str) -> None:
+        """Write an autosave snapshot when the timer fires."""
+        if not self._is_dirty:
+            return
+
+        autosave_dir = os.path.join(project_dir, "autosave")
+        try:
+            self.project_io.save_project(
+                project_dir=autosave_dir,
+                project_name=f"{self._project_name}.autosave",
+                dataset_state=self.dataset_state,
+                validation_state=self.validation_state,
+                inference_state=self.inference_state,
+                created_at=self._created_at,
+                save_score_maps=False,
+            )
+            self.statusBar().showMessage("Autosaved", 3000)
+        except Exception as exc:
+            self.statusBar().showMessage(f"Autosave failed: {exc}", 5000)
+
+    # ================================================================== #
+    # COCO export / import
+    # ================================================================== #
+
+    def _export_coco(self) -> None:
+        """Open a save-file dialog and export annotations as a COCO JSON file."""
+        default_name = (
+            f"{Path(self.dataset_state.image_dir).name}_coco.json"
+            if self.dataset_state.image_dir
+            else "annotations.coco.json"
+        )
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Export COCO JSON", default_name, "JSON (*.json)"
+        )
+        if not path:
+            return
+        try:
+            self.project_io.export_coco(path, self.dataset_state)
+            QMessageBox.information(self, "Export COCO", f"Saved to:\n{path}")
+        except Exception as exc:
+            QMessageBox.critical(self, "Export COCO", f"Export failed:\n{exc}")
+
+    def _import_coco(self) -> None:
+        """Open a file dialog and import a COCO JSON file into the dataset."""
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Import COCO JSON", "", "JSON (*.json)"
+        )
+        if not path:
+            return
+        try:
+            self.io_controller.import_data_json(path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Import COCO", f"Import failed:\n{exc}")
+            return
+        self.annomate_view.refresh_class_combo()
+
+    # ================================================================== #
+    # Dirty state & title
+    # ================================================================== #
+
+    def _mark_dirty(self) -> None:
+        self._is_dirty = True
+        self._update_title()
+
+    def _clear_dirty(self) -> None:
+        self._is_dirty = False
+        self._update_title()
+
+    def _update_title(self) -> None:
+        if self._project_name:
+            dirty_marker = "*" if self._is_dirty else ""
+            self.setWindowTitle(f"{self._project_name}{dirty_marker} — {_APP_TITLE}")
+        else:
+            self.setWindowTitle(_APP_TITLE)
+
+    def _confirm_discard(self) -> bool:
+        """Ask whether to save or discard unsaved changes. Returns True to proceed."""
+        reply = QMessageBox.question(
+            self,
+            "Unsaved Changes",
+            "You have unsaved changes. Save before continuing?",
+            QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
+            QMessageBox.Save,
+        )
+        if reply == QMessageBox.Save:
+            self._save_project()
+            return True
+        elif reply == QMessageBox.Discard:
+            return True
+        return False  # Cancel
+
+    def closeEvent(self, event) -> None:
+        """Prompt to save unsaved changes before closing."""
+        if self._is_dirty:
+            reply = QMessageBox.question(
+                self,
+                "Unsaved Changes",
+                "You have unsaved changes. Save before closing?",
+                QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
+                QMessageBox.Save,
+            )
+            if reply == QMessageBox.Save:
+                self._save_project()
+                event.accept()
+            elif reply == QMessageBox.Discard:
+                event.accept()
+            else:
+                event.ignore()
+                return
+        self.autosave_manager.stop()
+        super().closeEvent(event)
+
+    # ================================================================== #
+    # Polygon transfer
+    # ================================================================== #
 
     def _handle_polygon_transfer(self, polygons: list, default_class: str):
         """Show class-selection dialog then forward polygons to AnnoMate."""
@@ -94,10 +419,10 @@ class AppWindow(QMainWindow):
 def main():
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
-    
+
     window = AppWindow()
     window.show()
-    
+
     sys.exit(app.exec())
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,5 @@
 import os
 import sys
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Optional
 
 from PySide6.QtWidgets import (
     QApplication, QMainWindow, QTabWidget, QVBoxLayout, QWidget, QInputDialog,
@@ -23,13 +20,11 @@ from models.validation_model import ValidationModel
 from controllers.io_controller import IOController
 from controllers.inference_controller import InferenceController
 from controllers.validation_controller import ValidationController
+from controllers.project_controller import ProjectController
 
 from views.annomate.window import ImageAnnotator
 from views.microsentry.window import MicroSentryWindow
 from views.validation.window import ValidationWindow
-
-from core.project_io import ProjectIO
-from core.autosave import AutosaveManager
 
 _APP_TITLE = "AnnoMate & MicroSentryAI"
 
@@ -56,20 +51,28 @@ class AppWindow(QMainWindow):
             self.dataset_model, self.inference_model
         )
         self.validation_controller = ValidationController(self.validation_model)
+        self.project_controller    = ProjectController(
+            self.dataset_model,
+            self.inference_model,
+            self.validation_model,
+            self.io_controller,
+            self.inference_controller,
+            parent=self,
+        )
 
         # Views
-        self.annomate_view    = ImageAnnotator(self.dataset_model, self.io_controller)
-        self.sentry_view      = MicroSentryWindow(
+        self.annomate_view   = ImageAnnotator(self.dataset_model, self.io_controller)
+        self.sentry_view     = MicroSentryWindow(
             self.dataset_model,
             self.inference_model,
             self.inference_controller,
             self.io_controller,
         )
-        self.validation_view  = ValidationWindow(
+        self.validation_view = ValidationWindow(
             self.validation_model, self.validation_controller
         )
 
-        # Cross-tab row sync via each view's public API
+        # Cross-tab row sync
         self.annomate_view.row_selection_changed.connect(self.sentry_view.select_row)
         self.sentry_view.row_selection_changed.connect(self.annomate_view.select_row)
 
@@ -87,20 +90,17 @@ class AppWindow(QMainWindow):
         layout.addWidget(self.tabs)
         self.setCentralWidget(central_widget)
 
-        # Project state
-        self._project_dir: Optional[str] = None
-        self._project_name: str = ""
-        self._is_dirty: bool = False
-        self._created_at: Optional[str] = None
-
-        # Project I/O helpers
-        self.project_io = ProjectIO()
-        self.autosave_manager = AutosaveManager(interval_minutes=5, parent=self)
-        self.autosave_manager.save_requested.connect(self._do_autosave)
-
-        # Dirty-state tracking
-        self.dataset_model.dataChanged.connect(self._mark_dirty)
-        self.dataset_model.modelReset.connect(self._mark_dirty)
+        # ProjectController owns dirty tracking; AppWindow just reacts
+        self.project_controller.dirty_changed.connect(self._update_title)
+        self.project_controller.project_saved.connect(
+            lambda path: self.statusBar().showMessage(f"Saved: {path}", 4000)
+        )
+        self.project_controller.autosave_written.connect(
+            lambda _: self.statusBar().showMessage("Autosaved", 3000)
+        )
+        self.project_controller.autosave_failed.connect(
+            lambda msg: self.statusBar().showMessage(f"Autosave failed: {msg}", 5000)
+        )
 
         self._build_menu()
 
@@ -109,71 +109,39 @@ class AppWindow(QMainWindow):
     # ================================================================== #
 
     def _build_menu(self) -> None:
-        """Build the File menu with project and export/import actions."""
-        menu_bar = self.menuBar()
-        file_menu = menu_bar.addMenu("&File")
+        file_menu = self.menuBar().addMenu("&File")
 
-        act_new = QAction("New Project", self)
-        act_new.setShortcut(QKeySequence("Ctrl+N"))
-        act_new.triggered.connect(self._new_project)
-        file_menu.addAction(act_new)
+        def add(label, shortcut, slot):
+            act = QAction(label, self)
+            if shortcut:
+                act.setShortcut(QKeySequence(shortcut))
+            act.triggered.connect(slot)
+            file_menu.addAction(act)
+            return act
 
-        act_open = QAction("Open Project…", self)
-        act_open.setShortcut(QKeySequence("Ctrl+O"))
-        act_open.triggered.connect(self._open_project)
-        file_menu.addAction(act_open)
-
-        act_save = QAction("Save Project", self)
-        act_save.setShortcut(QKeySequence("Ctrl+S"))
-        act_save.triggered.connect(self._save_project)
-        file_menu.addAction(act_save)
-
-        act_save_as = QAction("Save Project As…", self)
-        act_save_as.setShortcut(QKeySequence("Ctrl+Shift+S"))
-        act_save_as.triggered.connect(self._save_project_as)
-        file_menu.addAction(act_save_as)
-
+        add("New Project",        "Ctrl+N",       self._new_project)
+        add("Open Project…",      "Ctrl+O",       self._open_project)
+        add("Save Project",       "Ctrl+S",       self._save_project)
+        add("Save Project As…",   "Ctrl+Shift+S", self._save_project_as)
         file_menu.addSeparator()
-
-        act_export_coco = QAction("Export COCO JSON…", self)
-        act_export_coco.triggered.connect(self._export_coco)
-        file_menu.addAction(act_export_coco)
-
-        act_import_coco = QAction("Import COCO JSON…", self)
-        act_import_coco.triggered.connect(self._import_coco)
-        file_menu.addAction(act_import_coco)
-
+        add("Relocate Images…",   "",             self._relocate_images)
         file_menu.addSeparator()
-
-        act_exit = QAction("Exit", self)
-        act_exit.setShortcut(QKeySequence("Ctrl+Q"))
-        act_exit.triggered.connect(self.close)
-        file_menu.addAction(act_exit)
+        add("Export COCO JSON…",  "",             self._export_coco)
+        add("Import COCO JSON…",  "",             self._import_coco)
+        file_menu.addSeparator()
+        add("Exit",               "Ctrl+Q",       self.close)
 
     # ================================================================== #
     # Project slots
     # ================================================================== #
 
     def _new_project(self) -> None:
-        """Prompt to save if dirty, then clear all state and reset project tracking."""
-        if self._is_dirty and not self._confirm_discard():
+        if self.project_controller.is_dirty and not self._confirm_discard():
             return
-
-        self.dataset_state.clear()
-        self.inference_state.clear()
-        self.validation_state.clear()
-        self.dataset_model.beginResetModel()
-        self.dataset_model.endResetModel()
-
-        self._project_dir = None
-        self._project_name = ""
-        self._created_at = None
-        self.autosave_manager.stop()
-        self._clear_dirty()
+        self.project_controller.new_project()
 
     def _open_project(self) -> None:
-        """Open a file dialog to select a .annoproj file, then load the project."""
-        if self._is_dirty and not self._confirm_discard():
+        if self.project_controller.is_dirty and not self._confirm_discard():
             return
 
         path, _ = QFileDialog.getOpenFileName(
@@ -183,66 +151,38 @@ class AppWindow(QMainWindow):
             return
 
         try:
-            project_data = self.project_io.load_project(path)
+            project_data, warnings = self.project_controller.open_project(path)
         except Exception as exc:
-            QMessageBox.critical(self, "Open Project", f"Could not read project file:\n{exc}")
+            QMessageBox.critical(self, "Open Project", f"Could not read project:\n{exc}")
             return
 
-        image_dir = project_data.get("dataset", {}).get("image_dir", "")
-        if image_dir and os.path.isdir(image_dir):
-            try:
-                self.io_controller.load_folder(image_dir)
-            except Exception as exc:
-                QMessageBox.warning(
-                    self, "Open Project",
-                    f"Image directory not accessible:\n{image_dir}\n\n{exc}\n\n"
-                    "Annotations will be loaded but images may not display."
-                )
-        elif image_dir:
-            QMessageBox.warning(
-                self, "Open Project",
-                f"Image directory not found:\n{image_dir}\n\n"
-                "Annotations will be loaded but images may not display."
-            )
-
-        try:
-            self.project_io.apply_project_to_states(
-                project_data,
-                self.dataset_state,
-                self.validation_state,
-                self.inference_state,
-            )
-        except Exception as exc:
-            QMessageBox.critical(self, "Open Project", f"Could not apply project data:\n{exc}")
-            return
-
-        # Trigger full view refresh after state is populated
-        self.dataset_model.beginResetModel()
-        self.dataset_model.endResetModel()
         self.annomate_view.refresh_class_combo()
 
-        self._project_dir = str(Path(path).parent)
-        self._project_name = project_data.get("project_name", Path(path).stem)
-        self._created_at = project_data.get("created_at")
-        self.autosave_manager.set_project_dir(self._project_dir)
-        self._clear_dirty()
+        if warnings:
+            QMessageBox.warning(self, "Open Project", "\n\n".join(warnings))
+
+        # Surface the previously-used model path (informational)
+        model_path = project_data.get("inference", {}).get("model_path", "")
+        if model_path and not self.inference_controller.has_model():
+            self.statusBar().showMessage(
+                f"Previous model: {model_path} — reload it in MicroSentry AI if needed.",
+                8000,
+            )
 
     def _save_project(self) -> None:
-        """Save to the current project directory, or prompt for one if not set."""
-        if self._project_dir is None:
+        if not self.project_controller.has_project:
             self._save_project_as()
             return
-
-        self._write_project(self._project_dir, self._project_name)
+        self._check_orphans_then_save(self.project_controller.save_project)
 
     def _save_project_as(self) -> None:
-        """Prompt for a project name and parent directory, then save."""
         parent_dir = QFileDialog.getExistingDirectory(
             self, "Choose Project Folder", os.getcwd()
         )
         if not parent_dir:
             return
 
+        from pathlib import Path
         default_name = (
             Path(self.dataset_state.image_dir).name
             if self.dataset_state.image_dir
@@ -256,78 +196,70 @@ class AppWindow(QMainWindow):
 
         name = name.strip()
         project_dir = os.path.join(parent_dir, name)
+        self._check_orphans_then_save(
+            lambda: self.project_controller.save_project_as(project_dir, name)
+        )
 
-        self._project_dir = project_dir
-        self._project_name = name
-        self._write_project(project_dir, name)
-        self.autosave_manager.set_project_dir(project_dir)
-
-    def _write_project(self, project_dir: str, project_name: str) -> None:
-        """Perform the actual disk write and update dirty/title state."""
-        try:
-            annoproj_path = self.project_io.save_project(
-                project_dir=project_dir,
-                project_name=project_name,
-                dataset_state=self.dataset_state,
-                validation_state=self.validation_state,
-                inference_state=self.inference_state,
-                created_at=self._created_at,
-                save_score_maps=True,
+    def _check_orphans_then_save(self, save_fn) -> None:
+        """Show orphaned-annotation warning if needed, then call save_fn."""
+        warning = self.project_controller.orphaned_annotations_warning()
+        if warning:
+            reply = QMessageBox.warning(
+                self, "Orphaned Annotations", warning,
+                QMessageBox.Ok | QMessageBox.Cancel,
+                QMessageBox.Cancel,
             )
-        except Exception as exc:
-            QMessageBox.critical(self, "Save Project", f"Could not save project:\n{exc}")
-            return
-
-        if self._created_at is None:
-            self._created_at = datetime.now(timezone.utc).isoformat()
-
-        self._clear_dirty()
-        self.statusBar().showMessage(f"Saved: {annoproj_path}", 4000)
-
-    def _do_autosave(self, project_dir: str) -> None:
-        """Write an autosave snapshot when the timer fires."""
-        if not self._is_dirty:
-            return
-
-        autosave_dir = os.path.join(project_dir, "autosave")
+            if reply != QMessageBox.Ok:
+                return
         try:
-            self.project_io.save_project(
-                project_dir=autosave_dir,
-                project_name=f"{self._project_name}.autosave",
-                dataset_state=self.dataset_state,
-                validation_state=self.validation_state,
-                inference_state=self.inference_state,
-                created_at=self._created_at,
-                save_score_maps=False,
-            )
-            self.statusBar().showMessage("Autosaved", 3000)
+            save_fn()
         except Exception as exc:
-            self.statusBar().showMessage(f"Autosave failed: {exc}", 5000)
+            QMessageBox.critical(self, "Save Project", f"Could not save:\n{exc}")
+
+    def _relocate_images(self) -> None:
+        """Point to a new image directory without clearing annotations."""
+        new_dir = QFileDialog.getExistingDirectory(
+            self, "Select New Image Folder", os.getcwd()
+        )
+        if not new_dir:
+            return
+        try:
+            self.project_controller.relocate_images(new_dir)
+        except Exception as exc:
+            QMessageBox.critical(self, "Relocate Images", f"Could not scan folder:\n{exc}")
+            return
+        self.annomate_view.refresh_class_combo()
+
+        orphan_msg = self.project_controller.orphaned_annotations_warning()
+        if orphan_msg:
+            QMessageBox.information(
+                self, "Annotations After Relocation",
+                orphan_msg.replace("Continue?", "They will be dropped on the next save.")
+            )
 
     # ================================================================== #
     # COCO export / import
     # ================================================================== #
 
     def _export_coco(self) -> None:
-        """Open a save-file dialog and export annotations as a COCO JSON file."""
-        default_name = (
+        from pathlib import Path
+        default = (
             f"{Path(self.dataset_state.image_dir).name}_coco.json"
             if self.dataset_state.image_dir
             else "annotations.coco.json"
         )
         path, _ = QFileDialog.getSaveFileName(
-            self, "Export COCO JSON", default_name, "JSON (*.json)"
+            self, "Export COCO JSON", default, "JSON (*.json)"
         )
         if not path:
             return
         try:
-            self.project_io.export_coco(path, self.dataset_state)
+            self.project_controller.export_coco(path)
             QMessageBox.information(self, "Export COCO", f"Saved to:\n{path}")
         except Exception as exc:
             QMessageBox.critical(self, "Export COCO", f"Export failed:\n{exc}")
 
     def _import_coco(self) -> None:
-        """Open a file dialog and import a COCO JSON file into the dataset."""
         path, _ = QFileDialog.getOpenFileName(
             self, "Import COCO JSON", "", "JSON (*.json)"
         )
@@ -341,29 +273,21 @@ class AppWindow(QMainWindow):
         self.annomate_view.refresh_class_combo()
 
     # ================================================================== #
-    # Dirty state & title
+    # Title & close
     # ================================================================== #
 
-    def _mark_dirty(self) -> None:
-        self._is_dirty = True
-        self._update_title()
-
-    def _clear_dirty(self) -> None:
-        self._is_dirty = False
-        self._update_title()
-
-    def _update_title(self) -> None:
-        if self._project_name:
-            dirty_marker = "*" if self._is_dirty else ""
-            self.setWindowTitle(f"{self._project_name}{dirty_marker} — {_APP_TITLE}")
+    def _update_title(self, is_dirty: bool = None) -> None:
+        name = self.project_controller.project_name
+        if name:
+            dirty = "*" if self.project_controller.is_dirty else ""
+            self.setWindowTitle(f"{name}{dirty} — {_APP_TITLE}")
         else:
             self.setWindowTitle(_APP_TITLE)
 
     def _confirm_discard(self) -> bool:
-        """Ask whether to save or discard unsaved changes. Returns True to proceed."""
+        """Prompt save/discard for unsaved changes. Returns True to proceed."""
         reply = QMessageBox.question(
-            self,
-            "Unsaved Changes",
+            self, "Unsaved Changes",
             "You have unsaved changes. Save before continuing?",
             QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
             QMessageBox.Save,
@@ -371,16 +295,12 @@ class AppWindow(QMainWindow):
         if reply == QMessageBox.Save:
             self._save_project()
             return True
-        elif reply == QMessageBox.Discard:
-            return True
-        return False  # Cancel
+        return reply == QMessageBox.Discard
 
     def closeEvent(self, event) -> None:
-        """Prompt to save unsaved changes before closing."""
-        if self._is_dirty:
+        if self.project_controller.is_dirty:
             reply = QMessageBox.question(
-                self,
-                "Unsaved Changes",
+                self, "Unsaved Changes",
                 "You have unsaved changes. Save before closing?",
                 QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
                 QMessageBox.Save,
@@ -393,7 +313,7 @@ class AppWindow(QMainWindow):
             else:
                 event.ignore()
                 return
-        self.autosave_manager.stop()
+        self.project_controller.autosave_manager.stop()
         super().closeEvent(event)
 
     # ================================================================== #
@@ -401,7 +321,6 @@ class AppWindow(QMainWindow):
     # ================================================================== #
 
     def _handle_polygon_transfer(self, polygons: list, default_class: str):
-        """Show class-selection dialog then forward polygons to AnnoMate."""
         class_names = self.dataset_model.get_class_names()
         if not class_names:
             class_names = [default_class]
@@ -419,11 +338,10 @@ class AppWindow(QMainWindow):
 def main():
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
-
     window = AppWindow()
     window.show()
-
     sys.exit(app.exec())
+
 
 if __name__ == "__main__":
     main()

--- a/src/tests/unit/test_project_io.py
+++ b/src/tests/unit/test_project_io.py
@@ -1,0 +1,322 @@
+import json
+import pytest
+import numpy as np
+
+from core.project_io import ProjectIO
+from core.states.dataset_state import DatasetState
+from core.states.inference_state import InferenceState
+from core.states.validation_state import ValidationState
+
+
+# ------------------------------------------------------------------ #
+# Fixtures
+# ------------------------------------------------------------------ #
+
+@pytest.fixture
+def pio():
+    return ProjectIO()
+
+
+@pytest.fixture
+def dataset_state():
+    return DatasetState()
+
+
+@pytest.fixture
+def inference_state():
+    return InferenceState()
+
+
+@pytest.fixture
+def validation_state():
+    return ValidationState()
+
+
+def _make_dataset(tmp_path):
+    """Return a populated DatasetState with one image file on disk."""
+    img_dir = tmp_path / "images"
+    img_dir.mkdir()
+    # Write a minimal valid 1×1 PNG so PIL can read its size
+    from PIL import Image as PILImage
+    PILImage.new("RGB", (320, 240)).save(img_dir / "img001.jpg")
+
+    state = DatasetState()
+    state.image_dir = str(img_dir)
+    state.image_files = ["img001.jpg"]
+    state.add_class("Defect", (255, 0, 0))
+    state.add_annotation("img001.jpg", "Defect", [(10, 20), (50, 20), (50, 60)])
+    state.set_inspector("img001.jpg", "Alice")
+    state.set_note("img001.jpg", "test note")
+    return state
+
+
+# ------------------------------------------------------------------ #
+# Polygon serialization helpers
+# ------------------------------------------------------------------ #
+
+class TestPolyHelpers:
+    def test_poly_to_coco_seg_round_trip(self, pio):
+        poly = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+        seg = pio._poly_to_coco_seg(poly)
+        assert seg == [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]
+        assert pio._coco_seg_to_poly(seg) == poly
+
+    def test_coco_seg_to_poly_flat_list(self, pio):
+        # Some COCO files store the flat list without the outer wrapper
+        flat = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        result = pio._coco_seg_to_poly(flat)
+        assert result == [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+
+    def test_empty_segmentation_returns_empty(self, pio):
+        assert pio._coco_seg_to_poly([]) == []
+
+    def test_coco_annotation_has_required_keys(self, pio):
+        poly = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0)]
+        ann = pio._build_coco_annotation(1, 1, 1, poly)
+        for key in ("id", "image_id", "category_id", "segmentation", "area", "bbox", "iscrowd"):
+            assert key in ann
+        assert ann["iscrowd"] == 0
+        assert ann["area"] > 0
+        assert len(ann["bbox"]) == 4
+
+
+# ------------------------------------------------------------------ #
+# NPZ key sanitization
+# ------------------------------------------------------------------ #
+
+class TestNpzKeys:
+    def test_round_trip_dot_and_slash(self, pio):
+        fname = "subdir/image.001.jpg"
+        key = pio._filename_to_npz_key(fname)
+        assert "." not in key
+        assert "/" not in key
+        assert pio._npz_key_to_filename(key) == fname
+
+    def test_plain_name_unchanged_by_round_trip(self, pio):
+        fname = "plain_name"
+        assert pio._npz_key_to_filename(pio._filename_to_npz_key(fname)) == fname
+
+
+# ------------------------------------------------------------------ #
+# Image size reading
+# ------------------------------------------------------------------ #
+
+class TestReadImageSize:
+    def test_reads_real_image(self, pio, tmp_path):
+        from PIL import Image as PILImage
+        img_path = tmp_path / "test.png"
+        PILImage.new("RGB", (100, 200)).save(img_path)
+        assert pio._read_image_size(str(img_path)) == (100, 200)
+
+    def test_missing_image_returns_zeros(self, pio, tmp_path):
+        assert pio._read_image_size(str(tmp_path / "missing.jpg")) == (0, 0)
+
+
+# ------------------------------------------------------------------ #
+# COCO export / import
+# ------------------------------------------------------------------ #
+
+class TestCocoRoundTrip:
+    def test_export_produces_valid_json(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        coco_path = str(tmp_path / "out.coco.json")
+        pio.export_coco(coco_path, ds)
+
+        data = json.loads((tmp_path / "out.coco.json").read_text())
+        assert "images" in data
+        assert "annotations" in data
+        assert "categories" in data
+        assert len(data["images"]) == 1
+        assert len(data["annotations"]) == 1
+        assert data["images"][0]["file_name"] == "img001.jpg"
+        assert data["images"][0]["width"] == 320
+
+    def test_export_bbox_is_coco_format(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        coco_path = str(tmp_path / "out.coco.json")
+        pio.export_coco(coco_path, ds)
+        data = json.loads((tmp_path / "out.coco.json").read_text())
+        bbox = data["annotations"][0]["bbox"]
+        assert len(bbox) == 4
+        # [x_min, y_min, width, height] — all non-negative
+        assert all(v >= 0 for v in bbox)
+
+    def test_import_restores_annotations(self, pio, tmp_path):
+        ds_src = _make_dataset(tmp_path)
+        coco_path = str(tmp_path / "out.coco.json")
+        pio.export_coco(coco_path, ds_src)
+
+        ds_dst = DatasetState()
+        pio.import_coco(coco_path, ds_dst)
+
+        assert "Defect" in ds_dst.class_names
+        assert "img001.jpg" in ds_dst.annotations
+        poly = ds_dst.annotations["img001.jpg"][0]["polygon"]
+        assert len(poly) == 3
+
+    def test_import_merges_classes(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        coco_path = str(tmp_path / "out.coco.json")
+        pio.export_coco(coco_path, ds)
+
+        ds_dst = DatasetState()
+        ds_dst.add_class("Existing", (0, 255, 0))
+        pio.import_coco(coco_path, ds_dst)
+
+        assert "Existing" in ds_dst.class_names
+        assert "Defect" in ds_dst.class_names
+
+
+# ------------------------------------------------------------------ #
+# Full project save / load round-trip
+# ------------------------------------------------------------------ #
+
+class TestProjectRoundTrip:
+    def test_save_creates_required_files(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        vs = ValidationState()
+        vs.poly_path = "/some/path"
+        inf = InferenceState()
+
+        proj_dir = str(tmp_path / "proj")
+        pio.save_project(proj_dir, "myproject", ds, vs, inf)
+
+        assert (tmp_path / "proj" / "myproject.annoproj").exists()
+        assert (tmp_path / "proj" / "annotations.coco.json").exists()
+
+    def test_round_trip_restores_class_names(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        proj_dir = str(tmp_path / "proj")
+        path = pio.save_project(proj_dir, "myproject", ds, ValidationState(), InferenceState())
+
+        data = pio.load_project(path)
+        ds2 = DatasetState()
+        ds2.image_dir = ds.image_dir
+        ds2.image_files = list(ds.image_files)
+        pio.apply_project_to_states(data, ds2, ValidationState(), InferenceState())
+
+        assert "Defect" in ds2.class_names
+        assert ds2.class_colors["Defect"] == (255, 0, 0)
+
+    def test_round_trip_restores_annotations(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        proj_dir = str(tmp_path / "proj")
+        path = pio.save_project(proj_dir, "myproject", ds, ValidationState(), InferenceState())
+
+        data = pio.load_project(path)
+        ds2 = DatasetState()
+        ds2.image_dir = ds.image_dir
+        ds2.image_files = list(ds.image_files)
+        pio.apply_project_to_states(data, ds2, ValidationState(), InferenceState())
+
+        assert "img001.jpg" in ds2.annotations
+        assert len(ds2.annotations["img001.jpg"]) == 1
+
+    def test_round_trip_restores_inspector_and_note(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        proj_dir = str(tmp_path / "proj")
+        path = pio.save_project(proj_dir, "myproject", ds, ValidationState(), InferenceState())
+
+        data = pio.load_project(path)
+        ds2 = DatasetState()
+        ds2.image_dir = ds.image_dir
+        ds2.image_files = list(ds.image_files)
+        vs2 = ValidationState()
+        pio.apply_project_to_states(data, ds2, vs2, InferenceState())
+
+        assert ds2.inspectors.get("img001.jpg") == "Alice"
+        assert ds2.notes.get("img001.jpg") == "test note"
+
+    def test_round_trip_restores_validation_paths(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        vs = ValidationState()
+        vs.poly_path = "/poly"
+        vs.json_path = "/ann.json"
+        proj_dir = str(tmp_path / "proj")
+        path = pio.save_project(proj_dir, "myproject", ds, vs, InferenceState())
+
+        data = pio.load_project(path)
+        vs2 = ValidationState()
+        pio.apply_project_to_states(data, DatasetState(), vs2, InferenceState())
+
+        assert vs2.poly_path == "/poly"
+        assert vs2.json_path == "/ann.json"
+
+    def test_round_trip_restores_inference_cache(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        inf = InferenceState()
+        inf.inference_cache = {"img001.jpg": 0.87}
+        proj_dir = str(tmp_path / "proj")
+        path = pio.save_project(proj_dir, "myproject", ds, ValidationState(), inf)
+
+        data = pio.load_project(path)
+        inf2 = InferenceState()
+        pio.apply_project_to_states(data, DatasetState(), ValidationState(), inf2)
+
+        assert inf2.inference_cache.get("img001.jpg") == pytest.approx(0.87)
+
+    def test_score_maps_saved_and_restored(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        inf = InferenceState()
+        arr = np.array([[0.1, 0.9], [0.5, 0.3]], dtype=np.float32)
+        inf.score_maps["img001.jpg"] = arr
+        inf.inference_cache["img001.jpg"] = float(arr.max())
+
+        proj_dir = str(tmp_path / "proj")
+        path = pio.save_project(proj_dir, "myproject", ds, ValidationState(), inf, save_score_maps=True)
+        assert (tmp_path / "proj" / "scoremaps.npz").exists()
+
+        data = pio.load_project(path)
+        inf2 = InferenceState()
+        pio.apply_project_to_states(data, DatasetState(), ValidationState(), inf2)
+
+        assert "img001.jpg" in inf2.score_maps
+        np.testing.assert_array_almost_equal(inf2.score_maps["img001.jpg"], arr)
+
+    def test_skip_score_maps_flag(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        inf = InferenceState()
+        inf.score_maps["img001.jpg"] = np.zeros((4, 4), dtype=np.float32)
+
+        proj_dir = str(tmp_path / "proj")
+        pio.save_project(proj_dir, "myproject", ds, ValidationState(), inf, save_score_maps=False)
+
+        assert not (tmp_path / "proj" / "scoremaps.npz").exists()
+
+    def test_missing_coco_file_does_not_crash(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        proj_dir = str(tmp_path / "proj")
+        path = pio.save_project(proj_dir, "myproject", ds, ValidationState(), InferenceState())
+
+        # Remove the COCO file to simulate a corrupted/moved project
+        (tmp_path / "proj" / "annotations.coco.json").unlink()
+
+        data = pio.load_project(path)
+        ds2 = DatasetState()
+        ds2.image_dir = ds.image_dir
+        ds2.image_files = list(ds.image_files)
+        # Should not raise — annotations simply remain empty
+        pio.apply_project_to_states(data, ds2, ValidationState(), InferenceState())
+        assert ds2.annotations == {}
+
+    def test_relative_path_resolution(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        proj_dir = str(tmp_path / "proj")
+        path = pio.save_project(proj_dir, "myproject", ds, ValidationState(), InferenceState())
+
+        # Manually strip the absolute key to force relative-path fallback
+        data = pio.load_project(path)
+        data["annotations_file_abs"] = "/nonexistent/path/annotations.coco.json"
+        resolved = pio._resolve_coco_path(path, data)
+        assert resolved.endswith("annotations.coco.json")
+        assert "proj" in resolved
+
+    def test_project_schema_version_present(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        proj_dir = str(tmp_path / "proj")
+        path = pio.save_project(proj_dir, "myproject", ds, ValidationState(), InferenceState())
+
+        raw = json.loads((tmp_path / "proj" / "myproject.annoproj").read_text())
+        assert raw["version"] == ProjectIO.SCHEMA_VERSION
+        assert "created_at" in raw
+        assert "modified_at" in raw

--- a/src/tests/unit/test_project_io.py
+++ b/src/tests/unit/test_project_io.py
@@ -2,7 +2,7 @@ import json
 import pytest
 import numpy as np
 
-from core.project_io import ProjectIO
+from core.persistence.project_io import ProjectIO
 from core.states.dataset_state import DatasetState
 from core.states.inference_state import InferenceState
 from core.states.validation_state import ValidationState

--- a/src/views/annomate/window.py
+++ b/src/views/annomate/window.py
@@ -620,8 +620,14 @@ class ImageAnnotator(QMainWindow):
             QMessageBox.critical(self, "Import Error", str(e))
             return
 
-        # Re-sync class combo after import (class list may have changed)
-        # V2: model query
+        self.refresh_class_combo()
+
+    def refresh_class_combo(self) -> None:
+        """Re-populate the class combo box from the model.
+
+        Called after any external operation that may change the class
+        registry (project open, COCO import, etc.).
+        """
         self.class_combo.blockSignals(True)
         self.class_combo.clear()
         self.class_combo.addItems(self.model.get_class_names())

--- a/src/views/app_window.py
+++ b/src/views/app_window.py
@@ -1,0 +1,328 @@
+"""
+AppWindow — top-level application shell view.
+
+Rules (consistent with other views):
+  V1  All file/folder dialogs and message boxes live here, not in controllers.
+  V2  State is never accessed directly; all data reads go through model query APIs.
+  V3  No disk I/O here; controllers handle all file operations.
+  V4  Colors are (r, g, b) tuples until the last Qt draw boundary.
+"""
+
+import os
+
+from PySide6.QtWidgets import (
+    QMainWindow, QTabWidget, QVBoxLayout, QWidget, QInputDialog,
+    QFileDialog, QMessageBox,
+)
+from PySide6.QtGui import QAction, QKeySequence
+
+from views.annomate.window import ImageAnnotator
+from views.microsentry.window import MicroSentryWindow
+from views.validation.window import ValidationWindow
+
+_APP_TITLE = "AnnoMate & MicroSentryAI"
+
+
+class AppWindow(QMainWindow):
+    """Top-level application shell.
+
+    Owns the tab widget and the File menu. Receives all models and
+    controllers as constructor arguments — creates nothing itself.
+    All dialogs (QFileDialog, QMessageBox, QInputDialog) live here per V1.
+
+    Args:
+        dataset_model: DatasetTableModel instance.
+        inference_model: InferenceModel instance.
+        validation_model: ValidationModel instance.
+        io_controller: IOController instance.
+        inference_controller: InferenceController instance.
+        validation_controller: ValidationController instance.
+        project_controller: ProjectController instance.
+    """
+
+    def __init__(
+        self,
+        dataset_model,
+        inference_model,
+        validation_model,
+        io_controller,
+        inference_controller,
+        validation_controller,
+        project_controller,
+    ) -> None:
+        super().__init__()
+        self.setWindowTitle(_APP_TITLE)
+        self.resize(1400, 900)
+
+        self.dataset_model        = dataset_model
+        self.inference_model      = inference_model
+        self.validation_model     = validation_model
+        self.io_controller        = io_controller
+        self.inference_controller = inference_controller
+        self.validation_controller = validation_controller
+        self.project_controller   = project_controller
+
+        # Sub-views
+        self.annomate_view   = ImageAnnotator(dataset_model, io_controller)
+        self.sentry_view     = MicroSentryWindow(
+            dataset_model, inference_model, inference_controller, io_controller
+        )
+        self.validation_view = ValidationWindow(validation_model, validation_controller)
+
+        # Cross-tab row sync
+        self.annomate_view.row_selection_changed.connect(self.sentry_view.select_row)
+        self.sentry_view.row_selection_changed.connect(self.annomate_view.select_row)
+
+        # Polygon transfer: MicroSentry → AnnoMate
+        self.sentry_view.polygonsSent.connect(self._handle_polygon_transfer)
+
+        # Tab widget
+        self.tabs = QTabWidget()
+        self.tabs.addTab(self.annomate_view,   "AnnoMate")
+        self.tabs.addTab(self.sentry_view,     "MicroSentry AI")
+        self.tabs.addTab(self.validation_view, "Validation")
+
+        central = QWidget()
+        layout = QVBoxLayout(central)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.tabs)
+        self.setCentralWidget(central)
+
+        # React to ProjectController signals
+        self.project_controller.dirty_changed.connect(self._update_title)
+        self.project_controller.project_saved.connect(
+            lambda path: self.statusBar().showMessage(f"Saved: {path}", 4000)
+        )
+        self.project_controller.autosave_written.connect(
+            lambda _: self.statusBar().showMessage("Autosaved", 3000)
+        )
+        self.project_controller.autosave_failed.connect(
+            lambda msg: self.statusBar().showMessage(f"Autosave failed: {msg}", 5000)
+        )
+
+        self._build_menu()
+
+    # ================================================================== #
+    # Menu bar
+    # ================================================================== #
+
+    def _build_menu(self) -> None:
+        file_menu = self.menuBar().addMenu("&File")
+
+        def add(label, shortcut, slot):
+            act = QAction(label, self)
+            if shortcut:
+                act.setShortcut(QKeySequence(shortcut))
+            act.triggered.connect(slot)
+            file_menu.addAction(act)
+
+        add("New Project",       "Ctrl+N",       self._new_project)
+        add("Open Project…",     "Ctrl+O",       self._open_project)
+        add("Save Project",      "Ctrl+S",       self._save_project)
+        add("Save Project As…",  "Ctrl+Shift+S", self._save_project_as)
+        file_menu.addSeparator()
+        add("Relocate Images…",  "",             self._relocate_images)
+        file_menu.addSeparator()
+        add("Export COCO JSON…", "",             self._export_coco)
+        add("Import COCO JSON…", "",             self._import_coco)
+        file_menu.addSeparator()
+        add("Exit",              "Ctrl+Q",       self.close)
+
+    # ================================================================== #
+    # Project slots
+    # ================================================================== #
+
+    def _new_project(self) -> None:
+        if self.project_controller.is_dirty and not self._confirm_discard():
+            return
+        self.project_controller.new_project()
+
+    def _open_project(self) -> None:
+        if self.project_controller.is_dirty and not self._confirm_discard():
+            return
+
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Open Project", os.getcwd(), "AnnoMate Project (*.annoproj)"
+        )
+        if not path:
+            return
+
+        try:
+            project_data, warnings = self.project_controller.open_project(path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Open Project", f"Could not read project:\n{exc}")
+            return
+
+        self.annomate_view.refresh_class_combo()
+
+        if warnings:
+            QMessageBox.warning(self, "Open Project", "\n\n".join(warnings))
+
+        model_path = project_data.get("inference", {}).get("model_path", "")
+        if model_path and not self.inference_controller.has_model():
+            self.statusBar().showMessage(
+                f"Previous model: {model_path} — reload it in MicroSentry AI if needed.",
+                8000,
+            )
+
+    def _save_project(self) -> None:
+        if not self.project_controller.has_project:
+            self._save_project_as()
+            return
+        self._check_orphans_then_save(self.project_controller.save_project)
+
+    def _save_project_as(self) -> None:
+        parent_dir = QFileDialog.getExistingDirectory(
+            self, "Choose Project Folder", os.getcwd()
+        )
+        if not parent_dir:
+            return
+
+        # V2: use model query, not state directly
+        image_dir = self.dataset_model.get_image_dir()
+        from pathlib import Path
+        default_name = Path(image_dir).name if image_dir else "project"
+
+        name, ok = QInputDialog.getText(
+            self, "Project Name", "Enter project name:", text=default_name
+        )
+        if not ok or not name.strip():
+            return
+
+        name = name.strip()
+        project_dir = os.path.join(parent_dir, name)
+        self._check_orphans_then_save(
+            lambda: self.project_controller.save_project_as(project_dir, name)
+        )
+
+    def _check_orphans_then_save(self, save_fn) -> None:
+        """Show orphaned-annotation warning if needed, then call save_fn."""
+        warning = self.project_controller.orphaned_annotations_warning()
+        if warning:
+            reply = QMessageBox.warning(
+                self, "Orphaned Annotations", warning,
+                QMessageBox.Ok | QMessageBox.Cancel,
+                QMessageBox.Cancel,
+            )
+            if reply != QMessageBox.Ok:
+                return
+        try:
+            save_fn()
+        except Exception as exc:
+            QMessageBox.critical(self, "Save Project", f"Could not save:\n{exc}")
+
+    def _relocate_images(self) -> None:
+        """Point to a new image directory without clearing annotations."""
+        new_dir = QFileDialog.getExistingDirectory(
+            self, "Select New Image Folder", os.getcwd()
+        )
+        if not new_dir:
+            return
+        try:
+            self.project_controller.relocate_images(new_dir)
+        except Exception as exc:
+            QMessageBox.critical(self, "Relocate Images", f"Could not scan folder:\n{exc}")
+            return
+        self.annomate_view.refresh_class_combo()
+
+        orphan_msg = self.project_controller.orphaned_annotations_warning()
+        if orphan_msg:
+            QMessageBox.information(
+                self, "Annotations After Relocation",
+                orphan_msg.replace("Continue?", "They will be dropped on the next save.")
+            )
+
+    # ================================================================== #
+    # COCO export / import
+    # ================================================================== #
+
+    def _export_coco(self) -> None:
+        from pathlib import Path
+        image_dir = self.dataset_model.get_image_dir()
+        default = f"{Path(image_dir).name}_coco.json" if image_dir else "annotations.coco.json"
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Export COCO JSON", default, "JSON (*.json)"
+        )
+        if not path:
+            return
+        try:
+            self.project_controller.export_coco(path)
+            QMessageBox.information(self, "Export COCO", f"Saved to:\n{path}")
+        except Exception as exc:
+            QMessageBox.critical(self, "Export COCO", f"Export failed:\n{exc}")
+
+    def _import_coco(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Import COCO JSON", "", "JSON (*.json)"
+        )
+        if not path:
+            return
+        try:
+            self.io_controller.import_data_json(path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Import COCO", f"Import failed:\n{exc}")
+            return
+        self.annomate_view.refresh_class_combo()
+
+    # ================================================================== #
+    # Title, close, unsaved-changes guard
+    # ================================================================== #
+
+    def _update_title(self, is_dirty: bool = None) -> None:
+        name = self.project_controller.project_name
+        if name:
+            dirty = "*" if self.project_controller.is_dirty else ""
+            self.setWindowTitle(f"{name}{dirty} — {_APP_TITLE}")
+        else:
+            self.setWindowTitle(_APP_TITLE)
+
+    def _confirm_discard(self) -> bool:
+        """Prompt save/discard for unsaved changes. Returns True to proceed."""
+        reply = QMessageBox.question(
+            self, "Unsaved Changes",
+            "You have unsaved changes. Save before continuing?",
+            QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
+            QMessageBox.Save,
+        )
+        if reply == QMessageBox.Save:
+            self._save_project()
+            return True
+        return reply == QMessageBox.Discard
+
+    def closeEvent(self, event) -> None:
+        if self.project_controller.is_dirty:
+            reply = QMessageBox.question(
+                self, "Unsaved Changes",
+                "You have unsaved changes. Save before closing?",
+                QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
+                QMessageBox.Save,
+            )
+            if reply == QMessageBox.Save:
+                self._save_project()
+                event.accept()
+            elif reply == QMessageBox.Discard:
+                event.accept()
+            else:
+                event.ignore()
+                return
+        self.project_controller.autosave_manager.stop()
+        super().closeEvent(event)
+
+    # ================================================================== #
+    # Polygon transfer
+    # ================================================================== #
+
+    def _handle_polygon_transfer(self, polygons: list, default_class: str) -> None:
+        """Show class-selection dialog then forward polygons to AnnoMate."""
+        class_names = self.dataset_model.get_class_names()
+        if not class_names:
+            class_names = [default_class]
+
+        chosen, ok = QInputDialog.getItem(
+            self, "Choose Class", "Assign polygons to class:",
+            class_names,
+            class_names.index(default_class) if default_class in class_names else 0,
+            False,
+        )
+        if ok and chosen:
+            self.annomate_view.receive_polygons(polygons, chosen)


### PR DESCRIPTION
Introduces a full project save/load mechanic to the application. Work is no longer lost between sessions. This addresses issues seen in #26 and #27 

---

### What's New

**Project files (`.annoproj`) —** A JSON-based project file format that captures the full working session: image directory, annotation classes, all polygon annotations (stored in a linked COCO JSON file), per-image inspector names and notes, validation workflow paths, and inference scores. The project folder is self-contained and portable.

**COCO JSON annotations —** Annotations are serialized as standard COCO Instance Segmentation JSON, making them interoperable with other tools. The project file stores a relative path to the COCO file so the folder can be moved without breaking the link.

**Autosave —** A 5-minute timer writes a lightweight snapshot to an `autosave/` subfolder within the project directory. Score map arrays are skipped during autosave to keep writes fast. The autosave file is a valid project file and can be opened for crash recovery.

---

### Architecture

A new `ProjectController` owns the entire project lifecycle — dirty tracking, autosave coordination, open/save/relocate operations, and orphaned annotation detection. This keeps `AppWindow` as a pure view coordinator and project state out of the view layer.

A new `core/persistence/` module houses the headless serialization logic (`ProjectIO`) and the timer component (`AutosaveManager`), giving them a clear home separate from states, logic, and utilities.

---

### New User-Facing Features

* **File menu** with New Project, Open Project, Save Project, Save Project As, Export COCO JSON, Import COCO JSON, and Relocate Images actions
* **Relocate Images** — points an open project to a new image directory without clearing annotations
* **Dirty tracking** — the window title shows an asterisk when there are unsaved changes
* **Unsaved changes dialog** — prompts to save on close or when opening/creating a new project
* **Orphaned annotation warnings** — alerts before saving if any annotations reference files no longer in the image directory
* **Inference model path** — the path to the last-loaded model checkpoint is recorded in the project file and surfaced as a status bar hint on reload