### PR TITLE
Added a brush thickness slider on the tool bar

### DIFF
--- a/src/controllers/io_controller.py
+++ b/src/controllers/io_controller.py
@@ -135,6 +135,7 @@ class IOController:
                     {
                         "class": a["category_name"],
                         "polygon": [(float(x), float(y)) for (x, y) in a["polygon"]],
+                        "thickness": a.get("thickness", 2.0),
                     }
                     for a in anns
                 ],
@@ -289,7 +290,7 @@ class IOController:
             state.inspectors[name] = info.get("inspector", "")
             state.notes[name] = info.get("note", "")
             recs = [
-                {"category_name": a.get("class", ""), "polygon": a.get("polygon", [])}
+                {"category_name": a.get("class", ""), "polygon": a.get("polygon", []), "thickness": a.get("thickness", 2.0)}
                 for a in info.get("annotations", [])
             ]
             if recs:

--- a/src/core/states/dataset_state.py
+++ b/src/core/states/dataset_state.py
@@ -60,7 +60,7 @@ class DatasetState:
 
     # --- Annotation CRUD ---
 
-    def add_annotation(self, image_name: str, category: str, polygon: list) -> None:
+    def add_annotation(self, image_name: str, category: str, polygon: list, thickness: float = 2.0) -> None:
         """Append a new polygon annotation to an image.
 
         Args:
@@ -68,10 +68,17 @@ class DatasetState:
             category (str): Class name for the annotation.
             polygon (list): Sequence of (x, y) coordinate pairs defining
                 the polygon boundary.
+            thickness (float): Line thickness for the annotation (default: 2.0).
         """
         self.annotations.setdefault(image_name, []).append(
-            {"category_name": category, "polygon": polygon}
+            {"category_name": category, "polygon": polygon, "thickness": thickness}
         )
+
+    def update_annotation_thickness(self, image_name: str, index: int, thickness: float) -> None:
+        """Update the thickness of a specific polygon."""
+        annos = self.annotations.get(image_name, [])
+        if 0 <= index < len(annos):
+            annos[index]["thickness"] = thickness
 
     def delete_annotation(self, image_name: str, index: int) -> None:
         """Remove the annotation at *index* for *image_name*.

--- a/src/models/dataset_model.py
+++ b/src/models/dataset_model.py
@@ -137,7 +137,7 @@ class DatasetTableModel(QAbstractTableModel):
         self.state.image_files = files
         self.endResetModel()
 
-    def add_annotation(self, row: int, category: str, polygon: list) -> None:
+    def add_annotation(self, row: int, category: str, polygon: list, thickness: float = 2.0) -> None:
         """Append a polygon annotation to the image at *row*.
 
         Out-of-bounds *row* values are logged as errors and silently ignored.
@@ -148,6 +148,7 @@ class DatasetTableModel(QAbstractTableModel):
             category (str): Class name to assign to the annotation.
             polygon (list): Sequence of ``(x, y)`` coordinate pairs defining
                 the polygon boundary.
+            thickness (float): Line thickness for the annotation (default: 2.0).
         """
         if not (0 <= row < self.rowCount()):
             logger.error("Failed to add annotation: Row %d is out of bounds.", row)
@@ -156,7 +157,14 @@ class DatasetTableModel(QAbstractTableModel):
         filename = self.state.image_files[row]
         logger.debug("Adding '%s' annotation to '%s' (%d points)", category, filename, len(polygon))
 
-        self.state.add_annotation(filename, category, polygon)
+        self.state.add_annotation(filename, category, polygon, thickness)
+        self._emit_row(row)
+
+    def update_annotation_thickness(self, row: int, annotation_idx: int, thickness: float) -> None:
+        """Update the line thickness of an existing annotation."""
+        if not (0 <= row < self.rowCount()):
+            return
+        self.state.update_annotation_thickness(self.state.image_files[row], annotation_idx, thickness)
         self._emit_row(row)
 
     def delete_annotation(self, row: int, annotation_idx: int) -> None:

--- a/src/views/annomate/image_label.py
+++ b/src/views/annomate/image_label.py
@@ -84,6 +84,7 @@ class ImageLabel(QLabel):
 
         self.current_tool: Optional[str] = None
         self._active_color = QColor(0, 200, 0)
+        self._line_thickness = 2.0
 
         self._orig_image_bgr: Optional[np.ndarray] = None
         self._display_qpix: Optional[QPixmap] = None
@@ -229,6 +230,14 @@ class ImageLabel(QLabel):
         """
         self._active_color = color if isinstance(color, QColor) else QColor(0, 200, 0)
 
+    def set_line_thickness(self, thickness: float) -> None:
+        """Set the line thickness for drawing polygons and overlays.
+        
+        Args: thickness (float): The brush width in pixels.
+        """
+        self._line_thickness = thickness
+        self.update()
+
     def set_overlays(self, poly_list: List[Tuple[List[Tuple[float, float]], QColor]]) -> None:
         """Replace all rendered overlay polygons.
 
@@ -241,12 +250,12 @@ class ImageLabel(QLabel):
                 ``(x, y)`` tuples in original image coordinates.
         """
         self._overlays = []
-        for pts_orig, color in poly_list:
+        for pts_orig, color, thick in poly_list:
             disp_pts = [
                 QPointF(x * self._base_scale, y * self._base_scale)
                 for (x, y) in pts_orig
             ]
-            self._overlays.append((disp_pts, color))
+            self._overlays.append((disp_pts, color, thick))
 
         n = len(self._overlays)
         if self.editing_polygon_idx >= n:
@@ -392,7 +401,7 @@ class ImageLabel(QLabel):
         if event.button() == Qt.LeftButton:
             pos_disp = self.view_to_display(QPointF(event.pos()))
             found_idx = -1
-            for i, (pts, _) in enumerate(reversed(self._overlays)):
+            for i, (pts, _, _) in enumerate(reversed(self._overlays)):
                 if QPolygonF(pts).containsPoint(pos_disp, Qt.OddEvenFill):
                     found_idx = len(self._overlays) - 1 - i
                     break
@@ -431,7 +440,7 @@ class ImageLabel(QLabel):
 
             # --- PRE-CHECK: Identify if we clicked inside any existing polygon ---
             found_idx = -1
-            for i, (pts, _) in enumerate(reversed(self._overlays)):
+            for i, (pts, _, _) in enumerate(reversed(self._overlays)):
                 if QPolygonF(pts).containsPoint(pos_disp, Qt.OddEvenFill):
                     found_idx = len(self._overlays) - 1 - i
                     break
@@ -455,7 +464,7 @@ class ImageLabel(QLabel):
 
             # 1. Edit Mode: Vertex Dragging & Polygon Dragging
             if self.editing_polygon_idx != -1:
-                pts, _ = self._overlays[self.editing_polygon_idx]
+                pts, _, _ = self._overlays[self.editing_polygon_idx]
                 closest_idx = -1
                 min_dist = float('inf')
 
@@ -517,7 +526,7 @@ class ImageLabel(QLabel):
 
         if self.dragging_vertex_idx != -1 and self.editing_polygon_idx != -1:
             new_pos = self.view_to_display(self._mouse_pos)
-            pts, _ = self._overlays[self.editing_polygon_idx]
+            pts, _, _ = self._overlays[self.editing_polygon_idx]
             pts[self.dragging_vertex_idx] = new_pos
             self.update()
             return
@@ -527,7 +536,7 @@ class ImageLabel(QLabel):
             delta_view = self._mouse_pos - self._last_mouse_pos
             delta_disp = QPointF(delta_view.x() / self._zoom, delta_view.y() / self._zoom)
 
-            pts, _ = self._overlays[self.selected_polygon_idx]
+            pts, _, _ = self._overlays[self.selected_polygon_idx]
             for i in range(len(pts)):
                 pts[i] = QPointF(pts[i].x() + delta_disp.x(), pts[i].y() + delta_disp.y())
 
@@ -555,7 +564,7 @@ class ImageLabel(QLabel):
                 self.editing_polygon_idx = -1
                 self.setCursor(Qt.ArrowCursor)
                 return
-            pts, _ = self._overlays[self.editing_polygon_idx]
+            pts, _, _ = self._overlays[self.editing_polygon_idx]
             hovering = False
             for p_disp in pts:
                 p_view = QPointF(
@@ -586,7 +595,7 @@ class ImageLabel(QLabel):
             # sees is_dragging() == False and can safely refresh overlays.
             if self.dragging_vertex_idx != -1:
                 idx = self.editing_polygon_idx
-                pts, _ = self._overlays[idx]
+                pts, _, _ = self._overlays[idx]
                 pts_orig = [self.display_to_original(p) for p in pts]
                 self.dragging_vertex_idx = -1
                 self.polygonEdited.emit(idx, pts_orig)
@@ -595,7 +604,7 @@ class ImageLabel(QLabel):
             # Commit Polygon Drag
             if self._dragging_polygon:
                 idx = self.selected_polygon_idx
-                pts, _ = self._overlays[idx]
+                pts, _, _ = self._overlays[idx]
                 pts_orig = [self.display_to_original(p) for p in pts]
                 self._dragging_polygon = False
                 self._last_mouse_pos = None
@@ -703,10 +712,10 @@ class ImageLabel(QLabel):
             painter.setOpacity(1.0)
 
         # Draw Overlays with Selection Highlighting
-        for i, (pts, color) in enumerate(self._overlays):
+        for i, (pts, color, thick) in enumerate(self._overlays):
             if len(pts) >= 2:
                 is_selected = (i == self.selected_polygon_idx)
-                pen = QPen(color, 4 if is_selected else 2) # Thicker if selected
+                pen = QPen(color, (thick * 2.0) if is_selected else thick) # Thicker if selected
                 alpha = 150 if is_selected else 60         # Darker fill if selected
 
                 painter.setPen(pen)
@@ -735,7 +744,7 @@ class ImageLabel(QLabel):
 
         if self.current_tool == POLYGON and self.current_polygon_points:
             painter.setBrush(Qt.NoBrush)
-            painter.setPen(QPen(self._active_color, 2))
+            painter.setPen(QPen(self._active_color, self._line_thickness))
             painter.drawPolyline(QPolygonF(self.current_polygon_points))
 
             if self._mouse_pos:

--- a/src/views/annomate/window.py
+++ b/src/views/annomate/window.py
@@ -403,7 +403,7 @@ class ImageAnnotator(QMainWindow):
         current_class = self.class_combo.currentText()
         if not current_class:
             return
-        self.model.add_annotation(sel.currentIndex().row(), current_class, points)
+        self.model.add_annotation(sel.currentIndex().row(), current_class, points, self.canvas._line_thickness)
 
     def update_polygon_points(self, idx: int, points: list) -> None:
         """Commit updated vertex positions for an edited polygon to the model.
@@ -658,9 +658,9 @@ class ImageAnnotator(QMainWindow):
             self.ann_list.addItem(f"{a['category_name']} — {len(a['polygon'])} pts")
         self.ann_list.blockSignals(False)
 
-        # V4: tuple → QColor right at the draw boundary
+        # V4: tuple → QColor right at the draw boundary (added thickness with fallback)
         overlays = [
-            (a["polygon"], QColor(*self.model.get_class_color(a["category_name"])))
+            (a["polygon"], QColor(*self.model.get_class_color(a["category_name"])), a.get("thickness", 2.0))
             for a in annos
         ]
         self.canvas.set_overlays(overlays)

--- a/src/views/wip/tool_palette.py
+++ b/src/views/wip/tool_palette.py
@@ -9,13 +9,16 @@ in later phases without touching window.py.
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QFont
 from PySide6.QtWidgets import (
-    QFrame, QVBoxLayout, QToolButton, QButtonGroup, QSizePolicy,
+    QFrame, QVBoxLayout, QToolButton, QButtonGroup, QSizePolicy, QMenu, QWidgetAction, QSlider, QLabel, QHBoxLayout, QWidget
 )
 
 _TOOLS = [
     ("⬠", "polygon", "Polygon"),
 ]
 
+_SETTINGS = [
+    ("◢", "thickness", "Brush Thickness"),
+]
 
 class ToolPalette(QFrame):
     """Single-column tool panel.
@@ -25,9 +28,11 @@ class ToolPalette(QFrame):
 
     Signals:
         tool_selected (str): Emitted with the tool name when a button is pressed.
+        thickess_changed (float): Emitted when the brush thickness slider moves.
     """
 
     tool_selected = Signal(str)
+    thickness_changed = Signal(float)
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
@@ -59,6 +64,44 @@ class ToolPalette(QFrame):
             self._btn_group.addButton(btn)
             layout.addWidget(btn)
 
+        for icon, setting_name, tooltip in _SETTINGS:
+            if setting_name == "thickness":
+                btn_thickness = QToolButton()
+                btn_thickness.setText(icon)
+                btn_thickness.setToolTip(tooltip)
+                btn_thickness.setFixedSize(32, 30)
+                btn_thickness.setFont(font)
+                btn_thickness.setPopupMode(QToolButton.InstantPopup)
+                
+                thickness_menu = QMenu(self)
+                action = QWidgetAction(self)
+                
+                container = QWidget()
+                h_layout = QHBoxLayout(container)
+                h_layout.setContentsMargins(8, 4, 8, 4)
+                
+                # 1-40 step range ensures exact 0.25 intervals up to 10.00
+                self.slider_thickness = QSlider(Qt.Horizontal)
+                self.slider_thickness.setRange(1, 40) 
+                self.slider_thickness.setValue(8)      # 8 * 0.25 = 2.00px Default
+                self.slider_thickness.setTickPosition(QSlider.TickPosition.TicksBelow)
+                self.slider_thickness.setTickInterval(4) # Tick every 1.0px
+                self.slider_thickness.setMinimumWidth(150)
+                
+                self.lbl_thickness = QLabel("2.00 px")
+                self.lbl_thickness.setFixedWidth(55)
+                
+                h_layout.addWidget(self.slider_thickness)
+                h_layout.addWidget(self.lbl_thickness)
+                
+                action.setDefaultWidget(container)
+                thickness_menu.addAction(action)
+                btn_thickness.setMenu(thickness_menu)
+                
+                layout.addWidget(btn_thickness)
+
+                self.slider_thickness.valueChanged.connect(self._on_slider_changed)
+
         self._btn_group.buttonClicked.connect(self._on_btn_clicked)
 
     def _on_btn_clicked(self, btn: QToolButton) -> None:
@@ -69,6 +112,12 @@ class ToolPalette(QFrame):
         else:
             self._active_tool = tool_name
             self.tool_selected.emit(tool_name)
+    
+    def _on_slider_changed(self, value: int) -> None:
+        """Translate the 1-40 step integer to a strict 0.25 interval float and emit."""
+        thickness = value * 0.25
+        self.lbl_thickness.setText(f"{thickness:.2f} px")
+        self.thickness_changed.emit(thickness)
 
     def deselect_all(self) -> None:
         """Uncheck all tool buttons (called when the canvas cancels a tool)."""

--- a/src/views/wip/window.py
+++ b/src/views/wip/window.py
@@ -162,6 +162,7 @@ class WIPWindow(QWidget):
         self.canvas.polygonFinished.connect(self._on_polygon_finished)
         self.canvas.polygonEdited.connect(self._on_polygon_edited)
         self.canvas.toolCanceled.connect(self._on_tool_canceled)
+        self.canvas.polygonSelected.connect(self._on_canvas_polygon_selected)
         self.canvas.ai_polygon_clicked.connect(self._on_ai_polygon_clicked)
 
         # Canvas → status bar (live feedback)
@@ -183,6 +184,9 @@ class WIPWindow(QWidget):
 
         # Tool palette
         self.tool_palette.tool_selected.connect(self._on_tool_selected)
+
+        # Route thickness signal directly to canvas setter
+        self.tool_palette.thickness_changed.connect(self._on_thickness_changed)
 
         # Inference controller signals
         if self.inference_controller is not None:
@@ -317,7 +321,7 @@ class WIPWindow(QWidget):
         if not class_names:
             return
         target = self._active_class if self._active_class in class_names else class_names[0]
-        self.dataset_model.add_annotation(self._current_row, target, pts)
+        self.dataset_model.add_annotation(self._current_row, target, pts, self.canvas._line_thickness)
         self._refresh_canvas_render()
 
     def _on_polygon_edited(self, idx: int, pts: list) -> None:
@@ -329,25 +333,72 @@ class WIPWindow(QWidget):
         if self._current_row >= 0:
             self._refresh_canvas_render()
 
+    def _on_canvas_polygon_selected(self, idx: int) -> None:
+        """Sync the right panel list and slider when a polygon is clicked on the canvas."""
+        ann_section = self.right_panel.annotations
+        
+        # Safely deselect the old item in the list
+        if 0 <= ann_section._selected_idx < len(ann_section._row_widgets):
+            ann_section._row_widgets[ann_section._selected_idx].set_selected(False)
+        
+        # Select the new item in the list
+        ann_section._selected_idx = idx
+        if 0 <= idx < len(ann_section._row_widgets):
+            ann_section._row_widgets[idx].set_selected(True)
+            
+        # Trigger the normal selection logic (updates canvas & slider)
+        self._on_annotation_selected(idx)
+
     def _on_annotation_selected(self, idx: int) -> None:
+        """Apply selection to the canvas and sync the UI slider to match the polygon's thickness."""
         self.canvas.selected_polygon_idx = idx
         self.canvas.update()
+        
+        # Read the polygon's specific thickness and update the slider
+        if idx != -1 and self._current_row >= 0:
+            annos = self.dataset_model.get_annotations(self._current_row)
+            if 0 <= idx < len(annos):
+                thick = annos[idx].get("thickness", 2.0)
+                
+                # Block signals so setting the slider doesn't accidentally trigger a drawing update
+                self.tool_palette.slider_thickness.blockSignals(True)
+                self.tool_palette.slider_thickness.setValue(int(thick * 4)) # slider is 1-40
+                self.tool_palette.lbl_thickness.setText(f"{thick:.2f} px")
+                self.tool_palette.slider_thickness.blockSignals(False)
+                
+                self.canvas.set_line_thickness(thick)
 
     def _refresh_overlays(self) -> None:
         """Rebuild canvas overlays from annotations only (no AI polygons). V4: QColor here."""
+        current_sel = self.canvas.selected_polygon_idx
         annos = self.dataset_model.get_annotations(self._current_row)
         overlays = [
-            (a["polygon"], QColor(*self.dataset_model.get_class_color(a["category_name"])))
+            (a["polygon"], QColor(*self.dataset_model.get_class_color(a["category_name"])), a.get("thickness", 2.0))
             for a in annos
         ]
         self.canvas.selected_polygon_idx = -1
         self.canvas.set_overlays(overlays)
         self.canvas.clear_ai_overlays()
+        if 0 <= current_sel < len(overlays):
+            self.canvas.selected_polygon_idx = current_sel
+        else:
+            self.canvas.selected_polygon_idx = -1
 
     def _update_canvas_overlays(self, anno_overlays: list) -> None:
         """Push annotation overlays and current AI contours to the canvas."""
         self.canvas.set_overlays(anno_overlays)
         self.canvas.set_ai_overlays(self._current_ai_contours)
+
+    def _on_thickness_changed(self, thickness: float) -> None:
+        """Apply thickness based on current tool mode."""
+        # Always update the canvas so future drawing uses this thickness
+        self.canvas.set_line_thickness(thickness)
+        
+        # If we are NOT actively drawing, and a polygon is selected, mutate its data
+        if self._active_tool != "polygon":
+            idx = self.canvas.selected_polygon_idx
+            if idx != -1 and self._current_row >= 0:
+                self.dataset_model.update_annotation_thickness(self._current_row, idx, thickness)
 
     # ------------------------------------------------------------------ #
     # Microsentry toggle & rendering


### PR DESCRIPTION
Added a brush thickness slider on the left tool palette that allows users to change the thickness of a polygon before they draw it, while currently drawing, or by selecting it after drawing. Slider goes by intervals of .25 from .25 to 10. 

States are updated to used this dynamic thickness when polygons are selected, as well as save it out to JSON when exporting. 

This also addresses #13 