### PR TITLE
Persist and explain MicroSentryAI settings

### DIFF
--- a/src/core/persistence/project_io.py
+++ b/src/core/persistence/project_io.py
@@ -134,6 +134,9 @@ class ProjectIO:
                 "score_cache": dict(inference_state.inference_cache),
                 "score_maps_file": score_maps_file,
                 "model_path": self._make_relative_if_inside(model_path, project_dir),
+                "user_config": {
+                    "microsentry": dict(inference_state.microsentry_settings),
+                },
             },
         }
 
@@ -261,6 +264,8 @@ class ProjectIO:
         # Inference cache (float scores only — fast to restore)
         inf_data = project_data.get("inference", {})
         inference_state.inference_cache = dict(inf_data.get("score_cache", {}))
+        user_config = inf_data.get("user_config", {})
+        inference_state.set_microsentry_settings(user_config.get("microsentry", {}))
 
         # Score maps from NPZ (optional)
         npz_path = project_data.get("_resolved_npz_path", "")

--- a/src/core/states/inference_state.py
+++ b/src/core/states/inference_state.py
@@ -1,23 +1,42 @@
 import numpy as np
 
+_DEFAULT_MICROSENTRY_SETTINGS = {
+    "panel_enabled": False,
+    "heatmap_enabled": False,
+    "seg_enabled": False,
+    "seg_pct": 95,
+    "alpha": 0.45,
+    "sigma": 4,
+    "epsilon": 12,
+    "heat_min": 0,
+}
+
+
+def default_microsentry_settings() -> dict:
+    """Return a fresh copy of the default MicroSentryAI user settings."""
+    return dict(_DEFAULT_MICROSENTRY_SETTINGS)
+
 
 class InferenceState:
     """MicroSentryAI domain state container for inference results.
 
-    Stores inference score maps and peak anomaly scores keyed by image
-    filename. Contains zero Qt dependencies.
+    Stores inference score maps, peak anomaly scores, and reloadable
+    MicroSentryAI user settings. Contains zero Qt dependencies.
 
     Attributes:
         score_maps (dict[str, np.ndarray]): Full heatmap arrays indexed
             by image filename (e.g. ``{"img.jpg": np.ndarray}``).
         inference_cache (dict[str, float]): Peak anomaly scores indexed
             by image filename (e.g. ``{"img.jpg": 0.93}``).
+        microsentry_settings (dict): User-facing MicroSentryAI tuning
+            settings persisted in .annoproj project state.
     """
 
     def __init__(self) -> None:
-        """Initialize InferenceState with empty score maps and cache."""
+        """Initialize InferenceState with empty score maps, cache, and settings."""
         self.score_maps = {}  # { "img.jpg": np.ndarray }  full heatmap arrays
         self.inference_cache = {}  # { "img.jpg": float }  peak anomaly scores
+        self.microsentry_settings = default_microsentry_settings()
 
     def clear(self) -> None:
         """Clear all stored score maps and cached anomaly scores."""
@@ -57,3 +76,13 @@ class InferenceState:
                 ``False`` otherwise.
         """
         return filename in self.score_maps
+
+    def set_microsentry_settings(self, settings: dict) -> None:
+        """Replace persisted MicroSentryAI settings with validated known keys."""
+        if not isinstance(settings, dict):
+            return
+        merged = default_microsentry_settings()
+        for key in merged:
+            if key in settings:
+                merged[key] = settings[key]
+        self.microsentry_settings = merged

--- a/src/tests/unit/test_project_io.py
+++ b/src/tests/unit/test_project_io.py
@@ -278,6 +278,37 @@ class TestProjectRoundTrip:
 
         assert inf2.inference_cache.get("img001.jpg") == pytest.approx(0.87)
 
+    def test_round_trip_restores_microsentry_user_config(self, pio, tmp_path):
+        ds = _make_dataset(tmp_path)
+        inf = InferenceState()
+        inf.set_microsentry_settings(
+            {
+                "panel_enabled": True,
+                "heatmap_enabled": True,
+                "seg_enabled": True,
+                "seg_pct": 88,
+                "alpha": 0.65,
+                "sigma": 7,
+                "epsilon": 9,
+                "heat_min": 12,
+            }
+        )
+        proj_dir = str(tmp_path / "proj")
+        path = pio.save_project(proj_dir, "myproject", ds, ValidationState(), inf)
+
+        data = pio.load_project(path)
+        inf2 = InferenceState()
+        pio.apply_project_to_states(data, DatasetState(), ValidationState(), inf2)
+
+        assert inf2.microsentry_settings["panel_enabled"] is True
+        assert inf2.microsentry_settings["heatmap_enabled"] is True
+        assert inf2.microsentry_settings["seg_enabled"] is True
+        assert inf2.microsentry_settings["seg_pct"] == 88
+        assert inf2.microsentry_settings["alpha"] == pytest.approx(0.65)
+        assert inf2.microsentry_settings["sigma"] == 7
+        assert inf2.microsentry_settings["epsilon"] == 9
+        assert inf2.microsentry_settings["heat_min"] == 12
+
     def test_score_maps_saved_and_restored(self, pio, tmp_path):
         ds = _make_dataset(tmp_path)
         inf = InferenceState()

--- a/src/views/annomate/right_panel.py
+++ b/src/views/annomate/right_panel.py
@@ -166,6 +166,9 @@ class RightPanel(QWidget):
     def get_microsentry_settings(self) -> dict:
         return self._ms_section.get_settings()
 
+    def set_microsentry_settings(self, settings: dict) -> None:
+        self._ms_section.set_settings(settings)
+
     def show_microsentry_section(self) -> None:
         """Make the Microsentry section visible and expanded."""
         self._ms_collapsible.setVisible(True)

--- a/src/views/annomate/sections/microsentry.py
+++ b/src/views/annomate/sections/microsentry.py
@@ -4,13 +4,13 @@ MicrosentrySection — unified Microsentry controls panel for the AnnoMate right
 Layout (when model loaded):
   Load Model button
   Model name label
-  [Heatmap] toggle  +  Transparency slider
-  [Segmentation] toggle  +  Threshold slider
+  [Heatmap] toggle  +  Overlay opacity slider
+  [Segmentation] toggle  +  Detection sensitivity slider
   [Accept AI Polygons] button
-  ▸ Advanced Settings (collapsible)
-      Smoothing slider
-      Simplify Tolerance slider
-      Heatmap Minimum slider
+  ▸ Advanced Settings (collapsible) + Help button
+      Mask smoothness slider
+      Boundary simplification slider
+      Heatmap floor slider
 """
 
 import os
@@ -20,9 +20,11 @@ from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QHBoxLayout,
+    QDialog,
     QLabel,
     QPushButton,
     QSlider,
+    QTextBrowser,
     QToolButton,
 )
 
@@ -113,7 +115,7 @@ class MicrosentrySection(QWidget):
 
         lw.addSpacing(4)
 
-        # Heatmap toggle + transparency slider inline
+        # Heatmap toggle + overlay opacity slider inline
         self._btn_heatmap = QToolButton()
         self._btn_heatmap.setText("Heatmap")
         self._btn_heatmap.setCheckable(True)
@@ -125,6 +127,9 @@ class MicrosentrySection(QWidget):
         self._alpha = QSlider(Qt.Horizontal)
         self._alpha.setRange(0, 100)
         self._alpha.setValue(45)
+        self._alpha.setToolTip(
+            "Controls how visible the heatmap overlay is on top of the image."
+        )
         self._alpha.valueChanged.connect(
             lambda v: (self._alpha_val.setText(f"{v}%"), self._debounce.start())
         )
@@ -136,7 +141,7 @@ class MicrosentrySection(QWidget):
         heatmap_row.addWidget(self._alpha_val)
         lw.addLayout(heatmap_row)
 
-        # Segmentation toggle + threshold slider inline
+        # Segmentation toggle + detection sensitivity slider inline
         self._btn_seg = QToolButton()
         self._btn_seg.setText("Segmentation")
         self._btn_seg.setCheckable(True)
@@ -148,6 +153,10 @@ class MicrosentrySection(QWidget):
         self._thresh = QSlider(Qt.Horizontal)
         self._thresh.setRange(0, 100)
         self._thresh.setValue(95)
+        self._thresh.setToolTip(
+            "Controls the percentile cutoff used to generate anomaly masks; "
+            "higher values keep only stronger anomaly regions."
+        )
         self._thresh.valueChanged.connect(
             lambda v: (self._thresh_val.setText(str(v)), self._debounce.start())
         )
@@ -182,7 +191,19 @@ class MicrosentrySection(QWidget):
             self._btn_advanced.sizePolicy().verticalPolicy(),
         )
         self._btn_advanced.toggled.connect(self._on_advanced_toggled)
-        lw.addWidget(self._btn_advanced)
+
+        self._btn_advanced_help = QPushButton("Help")
+        self._btn_advanced_help.setToolTip(
+            "Explain what the advanced MicroSentryAI settings do"
+        )
+        self._btn_advanced_help.clicked.connect(self._show_advanced_help)
+
+        advanced_header = QHBoxLayout()
+        advanced_header.setContentsMargins(0, 0, 0, 0)
+        advanced_header.setSpacing(4)
+        advanced_header.addWidget(self._btn_advanced, stretch=1)
+        advanced_header.addWidget(self._btn_advanced_help)
+        lw.addLayout(advanced_header)
 
         self._advanced_widget = QWidget()
         aw = QVBoxLayout(self._advanced_widget)
@@ -195,10 +216,13 @@ class MicrosentrySection(QWidget):
         self._sigma = QSlider(Qt.Horizontal)
         self._sigma.setRange(0, 16)
         self._sigma.setValue(4)
+        self._sigma.setToolTip(
+            "Controls how much Gaussian smoothing is applied before mask generation."
+        )
         self._sigma.valueChanged.connect(
             lambda v: (self._sigma_val.setText(str(v)), self._debounce.start())
         )
-        aw.addWidget(_slider_row("Smoothing", self._sigma_val, self._sigma))
+        aw.addWidget(_slider_row("Mask smoothness", self._sigma_val, self._sigma))
 
         self._epsilon_val = QLabel("12")
         self._epsilon_val.setStyleSheet("font-size: 11px;")
@@ -206,11 +230,14 @@ class MicrosentrySection(QWidget):
         self._epsilon = QSlider(Qt.Horizontal)
         self._epsilon.setRange(0, 20)
         self._epsilon.setValue(12)
+        self._epsilon.setToolTip(
+            "Controls polygon simplification; higher values create simpler boundaries."
+        )
         self._epsilon.valueChanged.connect(
             lambda v: (self._epsilon_val.setText(str(v)), self._debounce.start())
         )
         aw.addWidget(
-            _slider_row("Simplify Tolerance", self._epsilon_val, self._epsilon)
+            _slider_row("Boundary simplification", self._epsilon_val, self._epsilon)
         )
 
         self._heat_min_val = QLabel("0%")
@@ -219,10 +246,13 @@ class MicrosentrySection(QWidget):
         self._heat_min = QSlider(Qt.Horizontal)
         self._heat_min.setRange(0, 100)
         self._heat_min.setValue(0)
+        self._heat_min.setToolTip(
+            "Hides lower-intensity heatmap values below this percentile."
+        )
         self._heat_min.valueChanged.connect(
             lambda v: (self._heat_min_val.setText(f"{v}%"), self._debounce.start())
         )
-        aw.addWidget(_slider_row("Heatmap Minimum", self._heat_min_val, self._heat_min))
+        aw.addWidget(_slider_row("Heatmap floor", self._heat_min_val, self._heat_min))
 
         self._advanced_widget.setVisible(False)
         lw.addWidget(self._advanced_widget)
@@ -242,6 +272,71 @@ class MicrosentrySection(QWidget):
         self._advanced_widget.setVisible(checked)
         self._btn_advanced.setText(f"{'▾' if checked else '▸'}  Advanced Settings")
 
+    def _show_advanced_help(self) -> None:
+        dialog = QDialog(self)
+        dialog.setWindowTitle("MicroSentryAI Advanced Settings")
+        dialog.resize(560, 420)
+
+        layout = QVBoxLayout(dialog)
+
+        help_view = QTextBrowser()
+        help_view.setOpenExternalLinks(False)
+        help_view.setHtml(
+            """
+            <h2>Advanced Settings Help</h2>
+            <p>
+              These controls tune how MicroSentryAI turns model heatmaps into
+              visual overlays and editable segmentation polygons.
+            </p>
+
+            <h3>Mask smoothness</h3>
+            <p>
+              Controls Gaussian smoothing before mask generation. Increase it
+              when the heatmap is noisy or produces speckled polygons. Lower it
+              when small defects are being blurred or missed.
+            </p>
+            <p><b>Tradeoff:</b> higher values reduce noise but can merge nearby
+              regions or soften small anomalies.</p>
+
+            <h3>Boundary simplification</h3>
+            <p>
+              Controls how aggressively AI-generated polygon boundaries are
+              simplified after segmentation. Increase it when polygons have too
+              many jagged points. Lower it when the boundary shape needs to stay
+              closer to the original mask.
+            </p>
+            <p><b>Tradeoff:</b> higher values create cleaner, simpler polygons
+              but may lose fine shape detail.</p>
+
+            <h3>Heatmap floor</h3>
+            <p>
+              Hides lower-intensity heatmap values below the selected percentile
+              so weak background signal does not dominate the overlay. Increase
+              it when the heatmap looks cluttered. Lower it when you want to see
+              weaker model responses.
+            </p>
+            <p><b>Tradeoff:</b> higher values make the overlay cleaner but can
+              hide subtle anomalies.</p>
+            """
+        )
+        layout.addWidget(help_view)
+
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(dialog.accept)
+        close_row = QHBoxLayout()
+        close_row.addStretch()
+        close_row.addWidget(close_btn)
+        layout.addLayout(close_row)
+
+        dialog.exec()
+
+    def _refresh_value_labels(self) -> None:
+        self._alpha_val.setText(f"{self._alpha.value()}%")
+        self._thresh_val.setText(str(self._thresh.value()))
+        self._sigma_val.setText(str(self._sigma.value()))
+        self._epsilon_val.setText(str(self._epsilon.value()))
+        self._heat_min_val.setText(f"{self._heat_min.value()}%")
+
     # ------------------------------------------------------------------ #
     # Public API
     # ------------------------------------------------------------------ #
@@ -258,6 +353,41 @@ class MicrosentrySection(QWidget):
         self._lbl_model_backend.setText("")
         self._lbl_no_model.setVisible(True)
         self._loaded_widget.setVisible(False)
+
+    def set_settings(self, settings: dict) -> None:
+        """Apply persisted MicroSentryAI user settings to the controls."""
+        if not settings:
+            return
+
+        widgets = (
+            self._btn_heatmap,
+            self._btn_seg,
+            self._alpha,
+            self._thresh,
+            self._sigma,
+            self._epsilon,
+            self._heat_min,
+        )
+        for widget in widgets:
+            widget.blockSignals(True)
+        try:
+            self._btn_heatmap.setChecked(
+                bool(settings.get("heatmap_enabled", self._btn_heatmap.isChecked()))
+            )
+            self._btn_seg.setChecked(
+                bool(settings.get("seg_enabled", self._btn_seg.isChecked()))
+            )
+            self._alpha.setValue(int(float(settings.get("alpha", 0.45)) * 100))
+            self._thresh.setValue(int(settings.get("seg_pct", 95)))
+            self._sigma.setValue(int(settings.get("sigma", 4)))
+            self._epsilon.setValue(int(settings.get("epsilon", 12)))
+            self._heat_min.setValue(int(settings.get("heat_min", 0)))
+        finally:
+            for widget in widgets:
+                widget.blockSignals(False)
+
+        self._btn_accept.setEnabled(self._btn_seg.isChecked())
+        self._refresh_value_labels()
 
     def get_settings(self) -> dict:
         return {

--- a/src/views/annomate/window.py
+++ b/src/views/annomate/window.py
@@ -223,6 +223,8 @@ class AnnoMateWindow(QWidget):
         parent: Optional Qt parent widget.
     """
 
+    microsentry_session_changed = Signal()
+
     def __init__(
         self,
         dataset_model,
@@ -244,6 +246,7 @@ class AnnoMateWindow(QWidget):
         self._current_ai_contours: list = []
         self._selected_ai_idx: int = -1
         self._saved_model_path: str = ""
+        self._restoring_microsentry_session: bool = False
         self._sam_controller = SAMController(parent=self)
         self._sam_loading: bool = False
         self._init_ui()
@@ -273,7 +276,7 @@ class AnnoMateWindow(QWidget):
             self._on_load_previous_model_requested
         )
         self.right_panel.microsentry_settings_changed.connect(
-            self._refresh_canvas_render
+            self._on_microsentry_settings_changed
         )
         self.right_panel.accept_polygons_requested.connect(self._on_accept_ai_polygons)
 
@@ -589,8 +592,60 @@ class AnnoMateWindow(QWidget):
     # ------------------------------------------------------------------ #
 
     def set_saved_model_path(self, path: str) -> None:
-        """Called by AppWindow after opening a project to record the saved model path."""
+        """Record the saved model path after opening a project."""
         self._saved_model_path = path
+
+    def get_microsentry_settings(self) -> dict:
+        """Return current MicroSentryAI user settings from the right panel."""
+        settings = self.right_panel.get_microsentry_settings()
+        settings["panel_enabled"] = self._microsentry_enabled
+        return settings
+
+    def set_microsentry_settings(self, settings: dict) -> None:
+        """Apply persisted MicroSentryAI user settings to the right panel."""
+        if not settings:
+            return
+        self.right_panel.set_microsentry_settings(settings)
+        self._refresh_canvas_render()
+
+    def begin_microsentry_restore(self) -> None:
+        """Suppress dirty signals while project-open restores MicroSentry state."""
+        self._restoring_microsentry_session = True
+
+    def end_microsentry_restore(self) -> None:
+        """Resume normal dirty tracking after project-open restore."""
+        self._restoring_microsentry_session = False
+
+    def load_saved_model_if_available(self) -> bool:
+        """Load the model saved in the project, preserving restored score maps."""
+        if (
+            self.inference_controller is None
+            or not self._saved_model_path
+            or not os.path.isfile(self._saved_model_path)
+        ):
+            return False
+        self._load_model_from_path(
+            self._saved_model_path, clear_existing_scores=False
+        )
+        return self.inference_controller.has_model()
+
+    def _on_microsentry_settings_changed(self) -> None:
+        """Persist changed MicroSentryAI settings and refresh the canvas."""
+        self._persist_microsentry_settings()
+        self._refresh_canvas_render()
+
+    def _persist_microsentry_settings(self) -> None:
+        """Store current MicroSentryAI UI state for project save/load."""
+        settings = self.right_panel.get_microsentry_settings()
+        settings["panel_enabled"] = self._microsentry_enabled
+        if self.inference_model is not None:
+            setter = getattr(self.inference_model, "set_microsentry_settings", None)
+            if setter is not None:
+                setter(settings)
+            else:
+                self.inference_model.state.set_microsentry_settings(settings)
+        if not self._restoring_microsentry_session:
+            self.microsentry_session_changed.emit()
 
     # ------------------------------------------------------------------ #
     # Microsentry toggle & rendering
@@ -611,6 +666,7 @@ class AnnoMateWindow(QWidget):
             self.right_panel.show_microsentry_section()
         else:
             self.right_panel.hide_microsentry_section()
+        self._persist_microsentry_settings()
         self._refresh_canvas_render()
 
     def _on_load_previous_model_requested(self) -> None:
@@ -628,7 +684,8 @@ class AnnoMateWindow(QWidget):
             QMessageBox.warning(
                 self,
                 "Load Previous Model",
-                f"The saved model file no longer exists:\n{self._saved_model_path}\n\nUse 'Load New' to browse for it.",
+                "The saved model file no longer exists:\n"
+                f"{self._saved_model_path}\n\nUse 'Load New' to browse for it.",
             )
             return
         self._load_model_from_path(self._saved_model_path)
@@ -646,7 +703,9 @@ class AnnoMateWindow(QWidget):
             return
         self._load_model_from_path(path)
 
-    def _load_model_from_path(self, path: str) -> None:
+    def _load_model_from_path(
+        self, path: str, clear_existing_scores: bool = True
+    ) -> None:
         self.status_bar.set_model_loading(True)
         QApplication.processEvents()
         try:
@@ -658,7 +717,8 @@ class AnnoMateWindow(QWidget):
         self.status_bar.set_model_loading(False)
         # Clear score maps from any previous model so the new model re-processes
         # everything rather than reusing stale heatmaps.
-        self.inference_model.clear()
+        if clear_existing_scores:
+            self.inference_model.clear()
         self._refresh_canvas_render()
         self.right_panel.set_model_loaded(name, path)
         self._start_pending_inference()

--- a/src/views/annomate/window.py
+++ b/src/views/annomate/window.py
@@ -624,9 +624,7 @@ class AnnoMateWindow(QWidget):
             or not os.path.isfile(self._saved_model_path)
         ):
             return False
-        self._load_model_from_path(
-            self._saved_model_path, clear_existing_scores=False
-        )
+        self._load_model_from_path(self._saved_model_path, clear_existing_scores=False)
         return self.inference_controller.has_model()
 
     def _on_microsentry_settings_changed(self) -> None:

--- a/src/views/app_window.py
+++ b/src/views/app_window.py
@@ -65,6 +65,9 @@ class AppWindow(QMainWindow):
         self.annomate_view = AnnoMateWindow(
             dataset_model, io_controller, inference_model, inference_controller
         )
+        self.annomate_view.microsentry_session_changed.connect(
+            self.project_controller.mark_dirty
+        )
 
         self.setCentralWidget(self.annomate_view)
 
@@ -154,11 +157,30 @@ class AppWindow(QMainWindow):
         if warnings:
             QMessageBox.warning(self, "Open Project", "\n\n".join(warnings))
 
-        model_path = project_data.get("inference", {}).get("model_path", "")
-        self.annomate_view.set_saved_model_path(model_path)
-        if model_path and not self.inference_controller.has_model():
+        inference_data = project_data.get("inference", {})
+        model_path = inference_data.get("model_path", "")
+        user_config = inference_data.get("user_config", {})
+        microsentry_settings = user_config.get("microsentry", {})
+        should_restore_microsentry = bool(
+            microsentry_settings.get("panel_enabled", bool(model_path))
+        )
+
+        self.annomate_view.begin_microsentry_restore()
+        try:
+            self.annomate_view.set_saved_model_path(model_path)
+            self.annomate_view.set_microsentry_settings(microsentry_settings)
+            self._ms_action.setChecked(should_restore_microsentry)
+            restored_model = (
+                self.annomate_view.load_saved_model_if_available()
+                if should_restore_microsentry
+                else False
+            )
+        finally:
+            self.annomate_view.end_microsentry_restore()
+
+        if should_restore_microsentry and model_path and not restored_model:
             self.statusBar().showMessage(
-                f"Previous model saved: {os.path.basename(model_path)} — use 'Load Previous' in the MicroSentryAI panel.",
+                f"Could not restore saved model: {os.path.basename(model_path)}",
                 8000,
             )
 


### PR DESCRIPTION
## Summary

This PR improves MicroSentryAI usability by clarifying advanced tuning controls and persisting those settings through .annoproj project state

## Changes

- Adds a Help button for MicroSentryAI advanced settings with definitions, use cases, and tradeoffs
- Keeps concise tooltips on the controls while moving longer explanations into a separate help dialog
- Stores MicroSentryAI user settings under inference.user_config.microsentry in .annoproj
- Persists settings such as MicroSentry panel state, heatmap/segmentation toggles, percentile threshold, overlay opacity, sigma, epsilon, and heatmap floor
- Restores the MicroSentry panel, saved settings, saved model path, image folder/project state, and existing score maps when reopening a project
- Adds ProjectIO round-trip coverage for the saved MicroSentry user config

## Notes

- This does not create an external preset/config file
- Existing .annoproj files remain compatible because missing MicroSentry config falls back to defaults

## Testing

- python -m pytest src/tests/unit/test_project_io.py
- python -m ruff check src/core/persistence/project_io.py src/core/states/inference_state.py src/tests/unit/test_project_io.py src/views/annomate/right_panel.py src/views/annomate/sections/microsentry.py src/views/annomate/window.py src/views/app_window.py