### PR TITLE
Improve main interface startup workflow

### DIFF
--- a/src/views/annomate/window.py
+++ b/src/views/annomate/window.py
@@ -9,14 +9,16 @@ import os
 
 import cv2
 import numpy as np
-from PySide6.QtCore import Qt, QEvent, QPointF, Signal
+from PySide6.QtCore import Qt, QEvent, QPointF, QTimer, Signal
 from PySide6.QtGui import QColor, QFont
 from PySide6.QtWidgets import (
     QWidget,
     QFrame,
     QVBoxLayout,
+    QLabel,
     QSizePolicy,
     QToolButton,
+    QPushButton,
     QFileDialog,
     QMessageBox,
     QHBoxLayout,
@@ -173,6 +175,148 @@ class _ReviewBar(QFrame):
         self.move(max(0, x), self._MARGIN)
 
 
+class _ProjectStartScreen(QFrame):
+    """Centered empty-state panel shown before a project or image folder is loaded."""
+
+    new_project_requested = Signal()
+    open_project_requested = Signal()
+    open_image_folder_requested = Signal()
+    open_recent_project_requested = Signal(str)
+    open_recent_image_folder_requested = Signal(str)
+
+    def __init__(self, parent: QWidget = None) -> None:
+        super().__init__(parent)
+        self.setFrameStyle(QFrame.StyledPanel | QFrame.Raised)
+        self.setAutoFillBackground(True)
+        self.setObjectName("ProjectStartScreen")
+        self.setStyleSheet(
+            """
+            QFrame#ProjectStartScreen {
+                border-radius: 10px;
+            }
+            QLabel#ProjectStartTitle {
+                font-size: 22px;
+                font-weight: bold;
+            }
+            QLabel#ProjectStartBody {
+                font-size: 13px;
+            }
+            QPushButton {
+                min-height: 30px;
+                padding-left: 12px;
+                padding-right: 12px;
+            }
+            """
+        )
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 22, 24, 22)
+        layout.setSpacing(12)
+
+        title = QLabel("Start a project")
+        title.setObjectName("ProjectStartTitle")
+        title.setAlignment(Qt.AlignCenter)
+        layout.addWidget(title)
+
+        body = QLabel(
+            "Open an existing .annoproj project, load a folder of images, "
+            "or start a fresh annotation session."
+        )
+        body.setObjectName("ProjectStartBody")
+        body.setAlignment(Qt.AlignCenter)
+        body.setWordWrap(True)
+        layout.addWidget(body)
+
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(8)
+
+        btn_open_project = QPushButton("Open Project")
+        btn_open_project.setToolTip("Open an existing .annoproj project")
+        btn_open_project.clicked.connect(
+            lambda: QTimer.singleShot(0, self.open_project_requested.emit)
+        )
+        btn_row.addWidget(btn_open_project)
+
+        btn_open_images = QPushButton("Open Image Folder")
+        btn_open_images.setToolTip("Load images from a local folder")
+        btn_open_images.clicked.connect(
+            lambda: QTimer.singleShot(0, self.open_image_folder_requested.emit)
+        )
+        btn_row.addWidget(btn_open_images)
+
+        btn_new = QPushButton("New Project")
+        btn_new.setToolTip("Start a new blank project")
+        btn_new.clicked.connect(
+            lambda: QTimer.singleShot(0, self.new_project_requested.emit)
+        )
+        btn_row.addWidget(btn_new)
+
+        layout.addLayout(btn_row)
+
+        self._recent_label = QLabel("Recent")
+        self._recent_label.setObjectName("ProjectStartBody")
+        self._recent_label.setStyleSheet("font-weight: bold;")
+        layout.addWidget(self._recent_label)
+
+        recent_row = QHBoxLayout()
+        recent_row.setSpacing(8)
+
+        self._recent_project_path = ""
+        self._btn_recent_project = QPushButton("Open Last Project")
+        self._btn_recent_project.clicked.connect(self._open_recent_project)
+        recent_row.addWidget(self._btn_recent_project)
+
+        self._recent_image_dir = ""
+        self._btn_recent_images = QPushButton("Open Last Image Folder")
+        self._btn_recent_images.clicked.connect(self._open_recent_images)
+        recent_row.addWidget(self._btn_recent_images)
+
+        layout.addLayout(recent_row)
+        self.set_recent_actions("", "")
+        self.adjustSize()
+
+    def set_recent_actions(self, project_path: str, image_dir: str) -> None:
+        """Show shortcuts to the last opened project and image folder."""
+        self._recent_project_path = project_path or ""
+        self._recent_image_dir = image_dir or ""
+
+        has_project = bool(self._recent_project_path)
+        has_images = bool(self._recent_image_dir)
+        self._recent_label.setVisible(has_project or has_images)
+        self._btn_recent_project.setVisible(has_project)
+        self._btn_recent_images.setVisible(has_images)
+
+        if has_project:
+            name = os.path.basename(self._recent_project_path)
+            self._btn_recent_project.setText(f"Last Project: {name}")
+            self._btn_recent_project.setToolTip(self._recent_project_path)
+
+        if has_images:
+            name = os.path.basename(os.path.normpath(self._recent_image_dir))
+            self._btn_recent_images.setText(f"Last Image Folder: {name}")
+            self._btn_recent_images.setToolTip(self._recent_image_dir)
+
+        self.adjustSize()
+
+    def _open_recent_project(self) -> None:
+        if self._recent_project_path:
+            QTimer.singleShot(
+                0,
+                lambda: self.open_recent_project_requested.emit(
+                    self._recent_project_path
+                ),
+            )
+
+    def _open_recent_images(self) -> None:
+        if self._recent_image_dir:
+            QTimer.singleShot(
+                0,
+                lambda: self.open_recent_image_folder_requested.emit(
+                    self._recent_image_dir
+                ),
+            )
+
+
 class _ZoomToolbar(QFrame):
     """Floating vertical toolbar with zoom-in, zoom-out, and reset-view buttons."""
 
@@ -222,6 +366,12 @@ class AnnoMateWindow(QWidget):
         io_controller: IOController instance.
         parent: Optional Qt parent widget.
     """
+
+    new_project_requested = Signal()
+    open_project_requested = Signal()
+    open_image_folder_requested = Signal()
+    open_recent_project_requested = Signal(str)
+    open_recent_image_folder_requested = Signal(str)
 
     def __init__(
         self,
@@ -323,6 +473,7 @@ class AnnoMateWindow(QWidget):
 
         self.status_bar = AnnoMateStatusBar(self)
         root.addWidget(self.status_bar)
+        self._set_start_screen_visible(self.dataset_model.rowCount() == 0)
 
     def _build_workspace(self) -> QWidget:
         workspace = QWidget()
@@ -342,6 +493,24 @@ class AnnoMateWindow(QWidget):
         self.canvas = ImageLabel(self)
         self.canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         splitter.addWidget(self.canvas)
+
+        self._start_screen = _ProjectStartScreen(self.canvas)
+        self._start_screen.new_project_requested.connect(
+            self.new_project_requested.emit
+        )
+        self._start_screen.open_project_requested.connect(
+            self.open_project_requested.emit
+        )
+        self._start_screen.open_image_folder_requested.connect(
+            self.open_image_folder_requested.emit
+        )
+        self._start_screen.open_recent_project_requested.connect(
+            self.open_recent_project_requested.emit
+        )
+        self._start_screen.open_recent_image_folder_requested.connect(
+            self.open_recent_image_folder_requested.emit
+        )
+        self._start_screen.raise_()
 
         self._zoom_toolbar = _ZoomToolbar(self.canvas, self.canvas)
         self._zoom_toolbar.raise_()
@@ -372,12 +541,37 @@ class AnnoMateWindow(QWidget):
         super().showEvent(event)
         self._zoom_toolbar.reposition(self.canvas.size())
         self._review_bar.reposition(self.canvas.size())
+        self._reposition_start_screen()
 
     def eventFilter(self, obj, event) -> bool:
         if obj is self.canvas and event.type() == QEvent.Resize:
             self._zoom_toolbar.reposition(event.size())
             self._review_bar.reposition(event.size())
+            self._reposition_start_screen()
         return super().eventFilter(obj, event)
+
+    def _set_start_screen_visible(self, visible: bool) -> None:
+        """Show the project start panel only while no dataset is loaded."""
+        self._start_screen.setVisible(visible)
+        if visible:
+            self._start_screen.raise_()
+            self._reposition_start_screen()
+
+    def set_project_start_state(self, last_project: str, last_image_dir: str) -> None:
+        """Update start-screen recent actions."""
+        self._start_screen.set_recent_actions(last_project, last_image_dir)
+        self._reposition_start_screen()
+
+    def _reposition_start_screen(self) -> None:
+        """Keep the empty-state panel centered in the canvas area."""
+        if not hasattr(self, "_start_screen"):
+            return
+        width = min(520, max(360, self.canvas.width() - 80))
+        self._start_screen.setFixedWidth(width)
+        self._start_screen.adjustSize()
+        x = max(0, (self.canvas.width() - self._start_screen.width()) // 2)
+        y = max(24, (self.canvas.height() - self._start_screen.height()) // 2)
+        self._start_screen.move(x, y)
 
     # ------------------------------------------------------------------ #
     # Navigation slots
@@ -397,11 +591,13 @@ class AnnoMateWindow(QWidget):
             self.canvas.clear_image()
             self.right_panel.set_current_row(-1)
             self.status_bar.set_class("")
+            self._set_start_screen_visible(True)
 
     def _load_row(self, row: int) -> None:
         bgr = self.io_controller.load_image_for_display(row)
         if bgr is None:
             return
+        self._set_start_screen_visible(False)
         self._current_bgr = bgr
         self._current_row = row
         self._review_bar.set_decision(self.dataset_model.get_review_decision(row))

--- a/src/views/app_window.py
+++ b/src/views/app_window.py
@@ -4,12 +4,18 @@ See MVC.md § Architecture Rules for the full layer contract.
 """
 
 import os
+import sys
 
+from PySide6.QtCore import QSettings, QTimer
 from PySide6.QtWidgets import (
-    QMainWindow,
-    QInputDialog,
     QFileDialog,
+    QInputDialog,
+    QMainWindow,
+    QMenuBar,
     QMessageBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
 )
 from PySide6.QtGui import QAction, QKeySequence
 
@@ -17,6 +23,8 @@ from views.validation.window import ValidationWindow
 from views.annomate.window import AnnoMateWindow
 
 _APP_TITLE = "AnnoMate & MicroSentryAI"
+_LAST_IMAGE_DIR_KEY = "recent/last_image_dir"
+_LAST_PROJECT_KEY = "recent/last_project"
 
 
 class AppWindow(QMainWindow):
@@ -57,22 +65,33 @@ class AppWindow(QMainWindow):
         self.inference_controller = inference_controller
         self.validation_controller = validation_controller
         self.project_controller = project_controller
+        self._settings = QSettings("LANL", "AnnoMateMicroSentryAI")
 
         # Sub-views
         self.validation_view = ValidationWindow(validation_model, validation_controller)
         self.validation_view.setWindowTitle("Validation")
-        self.validation_view.resize(900, 650)
         self.annomate_view = AnnoMateWindow(
             dataset_model, io_controller, inference_model, inference_controller
         )
-
-        self.setCentralWidget(self.annomate_view)
+        self.annomate_view.new_project_requested.connect(self._new_project)
+        self.annomate_view.open_project_requested.connect(self._open_project)
+        self.annomate_view.open_image_folder_requested.connect(self._open_image_folder)
+        self.annomate_view.open_recent_project_requested.connect(
+            self._open_recent_project
+        )
+        self.annomate_view.open_recent_image_folder_requested.connect(
+            self._open_recent_image_folder
+        )
 
         # React to ProjectController signals
         self.project_controller.dirty_changed.connect(self._update_title)
-        self.project_controller.project_saved.connect(
-            lambda path: self.statusBar().showMessage(f"Saved: {path}", 4000)
+        self.project_controller.dirty_changed.connect(
+            lambda _: self._update_start_screen_state()
         )
+        self.project_controller.project_opened.connect(
+            lambda _: self._update_start_screen_state()
+        )
+        self.project_controller.project_saved.connect(self._on_project_saved)
         self.project_controller.autosave_written.connect(
             lambda _: self.statusBar().showMessage("Autosaved", 3000)
         )
@@ -81,6 +100,13 @@ class AppWindow(QMainWindow):
         )
 
         self._build_menu()
+        self._install_central_widget()
+        self.dataset_model.modelReset.connect(self._update_start_screen_state)
+        self.dataset_model.dataChanged.connect(
+            lambda *_: self._update_start_screen_state()
+        )
+
+        self._update_start_screen_state()
 
     # ================================================================== #
     # Menu bar
@@ -93,29 +119,52 @@ class AppWindow(QMainWindow):
                 act.setShortcut(QKeySequence(shortcut))
             act.triggered.connect(slot)
             menu.addAction(act)
+            return act
 
         file_menu = self.menuBar().addMenu("&File")
-        add(file_menu, "New Project", "Ctrl+N", self._new_project)
-        add(file_menu, "Open Project…", "Ctrl+O", self._open_project)
-        add(file_menu, "Save Project", "Ctrl+S", self._save_project)
-        add(file_menu, "Save Project As…", "Ctrl+Shift+S", self._save_project_as)
+        self._new_project_action = add(
+            file_menu, "New Project", "Ctrl+N", self._new_project
+        )
+        self._open_project_action = add(
+            file_menu, "Open Project…", "Ctrl+O", self._open_project
+        )
+        self._save_project_action = add(
+            file_menu, "Save Project", "Ctrl+S", self._save_project
+        )
+        self._save_project_as_action = add(
+            file_menu, "Save Project As…", "Ctrl+Shift+S", self._save_project_as
+        )
         file_menu.addSeparator()
-        add(file_menu, "Open Image Folder…", "", self._open_image_folder)
-        add(file_menu, "Relocate Images…", "", self._relocate_images)
+        self._open_image_folder_action = add(
+            file_menu, "Open Image Folder…", "", self._open_image_folder
+        )
+        self._relocate_images_action = add(
+            file_menu, "Relocate Images…", "", self._relocate_images
+        )
         file_menu.addSeparator()
-        add(file_menu, "Preferences…", "", self._open_preferences)
+        self._preferences_action = add(
+            file_menu, "Preferences…", "", self._open_preferences
+        )
         file_menu.addSeparator()
-        add(file_menu, "Exit", "Ctrl+Q", self.close)
+        self._exit_action = add(file_menu, "Exit", "Ctrl+Q", self.close)
 
         data_menu = self.menuBar().addMenu("&Data")
-        add(data_menu, "Import JSON Data…", "", self._import_coco)
+        self._import_coco_action = add(
+            data_menu, "Import JSON Data…", "", self._import_coco
+        )
         data_menu.addSeparator()
-        add(data_menu, "Export Polygons + Data…", "", self._export_polygons)
-        add(data_menu, "Export Binary Masks…", "", self._export_binary_masks)
-        add(data_menu, "Export CSV…", "", self._export_csv)
+        self._export_polygons_action = add(
+            data_menu, "Export Polygons + Data…", "", self._export_polygons
+        )
+        self._export_masks_action = add(
+            data_menu, "Export Binary Masks…", "", self._export_binary_masks
+        )
+        self._export_csv_action = add(data_menu, "Export CSV…", "", self._export_csv)
 
         validation_menu = self.menuBar().addMenu("&Validation")
-        add(validation_menu, "Open Validation…", "", self._open_validation)
+        self._open_validation_action = add(
+            validation_menu, "Show Validation", "", self._open_validation
+        )
 
         view_menu = self.menuBar().addMenu("&Microsentry")
         self._ms_action = QAction("Enable MicroSentryAI", self)
@@ -123,6 +172,89 @@ class AppWindow(QMainWindow):
         self._ms_action.setToolTip("Toggle MicroSentryAI heatmap and segmentation")
         self._ms_action.toggled.connect(self.annomate_view._on_microsentry_toggled)
         view_menu.addAction(self._ms_action)
+
+    def _install_central_widget(self) -> None:
+        """Install the main workspace, with a macOS in-window menu strip."""
+        workspace = self._build_workspace_tabs()
+
+        if sys.platform != "darwin":
+            self.setCentralWidget(workspace)
+            return
+
+        central = QWidget(self)
+        layout = QVBoxLayout(central)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._build_in_window_menu_bar())
+        layout.addWidget(workspace, stretch=1)
+        self.setCentralWidget(central)
+
+    def _build_workspace_tabs(self) -> QTabWidget:
+        """Build the primary workspace tabs embedded in the main window."""
+        self._workspace_tabs = QTabWidget(self)
+        self._workspace_tabs.setDocumentMode(True)
+        self._workspace_tabs.addTab(self.annomate_view, "AnnoMate")
+        self._workspace_tabs.addTab(self.validation_view, "Validation")
+        return self._workspace_tabs
+
+    def _build_in_window_menu_bar(self) -> QMenuBar:
+        """Build a non-native menu strip for high-use macOS menus."""
+        menu_bar = QMenuBar(self)
+        menu_bar.setNativeMenuBar(False)
+        menu_bar.setObjectName("InWindowMenuBar")
+        menu_bar.setToolTip("Quick access to File, Data, and MicroSentry actions")
+
+        file_menu = menu_bar.addMenu("File")
+        file_menu.addAction(self._new_project_action)
+        file_menu.addAction(self._open_project_action)
+        file_menu.addAction(self._save_project_action)
+        file_menu.addAction(self._save_project_as_action)
+        file_menu.addSeparator()
+        file_menu.addAction(self._open_image_folder_action)
+        file_menu.addAction(self._relocate_images_action)
+
+        data_menu = menu_bar.addMenu("Data")
+        data_menu.addAction(self._import_coco_action)
+        data_menu.addSeparator()
+        data_menu.addAction(self._export_polygons_action)
+        data_menu.addAction(self._export_masks_action)
+        data_menu.addAction(self._export_csv_action)
+
+        microsentry_menu = menu_bar.addMenu("Microsentry")
+        microsentry_menu.addAction(self._ms_action)
+
+        return menu_bar
+
+    def _refocus_after_native_dialog(self) -> None:
+        """Return focus to the main window after macOS native dialogs close."""
+        if sys.platform == "darwin":
+            QTimer.singleShot(0, self.raise_)
+            QTimer.singleShot(0, self.activateWindow)
+
+    def _remember_recent_project(self, path: str) -> None:
+        if path:
+            self._settings.setValue(_LAST_PROJECT_KEY, path)
+
+    def _remember_recent_image_dir(self, path: str) -> None:
+        if path:
+            self._settings.setValue(_LAST_IMAGE_DIR_KEY, path)
+
+    def _last_project_path(self) -> str:
+        return self._settings.value(_LAST_PROJECT_KEY, "", type=str) or ""
+
+    def _last_image_dir(self) -> str:
+        return self._settings.value(_LAST_IMAGE_DIR_KEY, "", type=str) or ""
+
+    def _update_start_screen_state(self, *_) -> None:
+        self.annomate_view.set_project_start_state(
+            self._last_project_path(),
+            self._last_image_dir(),
+        )
+
+    def _on_project_saved(self, path: str) -> None:
+        self.statusBar().showMessage(f"Saved: {path}", 4000)
+        self._remember_recent_project(path)
+        self._update_start_screen_state()
 
     # ================================================================== #
     # Project slots
@@ -132,6 +264,7 @@ class AppWindow(QMainWindow):
         if self.project_controller.is_dirty and not self._confirm_discard():
             return
         self.project_controller.new_project()
+        self._update_start_screen_state()
 
     def _open_project(self) -> None:
         if self.project_controller.is_dirty and not self._confirm_discard():
@@ -140,9 +273,27 @@ class AppWindow(QMainWindow):
         path, _ = QFileDialog.getOpenFileName(
             self, "Open Project", os.getcwd(), "AnnoMate Project (*.annoproj)"
         )
+        self._refocus_after_native_dialog()
         if not path:
             return
 
+        self._open_project_path(path)
+
+    def _open_recent_project(self, path: str) -> None:
+        if not os.path.isfile(path):
+            QMessageBox.warning(
+                self,
+                "Recent Project",
+                f"Could not find the last project:\n{path}",
+            )
+            self._settings.remove(_LAST_PROJECT_KEY)
+            self._update_start_screen_state()
+            return
+        if self.project_controller.is_dirty and not self._confirm_discard():
+            return
+        self._open_project_path(path)
+
+    def _open_project_path(self, path: str) -> None:
         try:
             project_data, warnings = self.project_controller.open_project(path)
         except Exception as exc:
@@ -154,6 +305,11 @@ class AppWindow(QMainWindow):
         if warnings:
             QMessageBox.warning(self, "Open Project", "\n\n".join(warnings))
 
+        self._remember_recent_project(path)
+        image_dir = self.dataset_model.get_image_dir()
+        if image_dir:
+            self._remember_recent_image_dir(image_dir)
+
         model_path = project_data.get("inference", {}).get("model_path", "")
         self.annomate_view.set_saved_model_path(model_path)
         if model_path and not self.inference_controller.has_model():
@@ -161,6 +317,7 @@ class AppWindow(QMainWindow):
                 f"Previous model saved: {os.path.basename(model_path)} — use 'Load Previous' in the MicroSentryAI panel.",
                 8000,
             )
+        self._update_start_screen_state()
 
     def _save_project(self) -> None:
         if not self.project_controller.has_project:
@@ -172,6 +329,7 @@ class AppWindow(QMainWindow):
         parent_dir = QFileDialog.getExistingDirectory(
             self, "Choose Project Folder", os.getcwd()
         )
+        self._refocus_after_native_dialog()
         if not parent_dir:
             return
 
@@ -215,15 +373,34 @@ class AppWindow(QMainWindow):
         directory = QFileDialog.getExistingDirectory(
             self, "Open Image Folder", os.getcwd()
         )
+        self._refocus_after_native_dialog()
         if not directory:
             return
+        self._open_image_folder_path(directory)
+
+    def _open_recent_image_folder(self, directory: str) -> None:
+        if not os.path.isdir(directory):
+            QMessageBox.warning(
+                self,
+                "Recent Image Folder",
+                f"Could not find the last image folder:\n{directory}",
+            )
+            self._settings.remove(_LAST_IMAGE_DIR_KEY)
+            self._update_start_screen_state()
+            return
+        self._open_image_folder_path(directory)
+
+    def _open_image_folder_path(self, directory: str) -> None:
         self.io_controller.load_folder(directory)
+        self._remember_recent_image_dir(directory)
+        self._update_start_screen_state()
 
     def _relocate_images(self) -> None:
         """Point to a new image directory without clearing annotations."""
         new_dir = QFileDialog.getExistingDirectory(
             self, "Select New Image Folder", os.getcwd()
         )
+        self._refocus_after_native_dialog()
         if not new_dir:
             return
         try:
@@ -233,6 +410,8 @@ class AppWindow(QMainWindow):
                 self, "Relocate Images", f"Could not scan folder:\n{exc}"
             )
             return
+        self._remember_recent_image_dir(new_dir)
+        self._update_start_screen_state()
 
         orphan_msg = self.project_controller.orphaned_annotations_warning()
         if orphan_msg:
@@ -255,6 +434,7 @@ class AppWindow(QMainWindow):
         path, _ = QFileDialog.getOpenFileName(
             self, "Import JSON Data", "", "JSON (*.json)"
         )
+        self._refocus_after_native_dialog()
         if not path:
             return
         try:
@@ -267,6 +447,7 @@ class AppWindow(QMainWindow):
         out_dir = QFileDialog.getExistingDirectory(
             self, "Choose output folder", os.getcwd()
         )
+        self._refocus_after_native_dialog()
         if not out_dir:
             return
         try:
@@ -279,6 +460,7 @@ class AppWindow(QMainWindow):
         out_dir = QFileDialog.getExistingDirectory(
             self, "Choose ground truth output folder", os.getcwd()
         )
+        self._refocus_after_native_dialog()
         if not out_dir:
             return
         try:
@@ -291,6 +473,7 @@ class AppWindow(QMainWindow):
         out_path, _ = QFileDialog.getSaveFileName(
             self, "Save CSV", "metadata.csv", "CSV (*.csv)"
         )
+        self._refocus_after_native_dialog()
         if not out_path:
             return
         try:
@@ -346,6 +529,4 @@ class AppWindow(QMainWindow):
         super().closeEvent(event)
 
     def _open_validation(self) -> None:
-        self.validation_view.show()
-        self.validation_view.raise_()
-        self.validation_view.activateWindow()
+        self._workspace_tabs.setCurrentWidget(self.validation_view)


### PR DESCRIPTION
## Summary

This PR improves the main application workflow by reducing macOS menu friction, embedding Validation into the main workspace, and adding a cleaner startup path for users.

## Changes

- Embeds Validation as a main workspace tab instead of opening it as a separate pop-up window
- Adds File actions to the in-app macOS menu strip for easier access in fullscreen workflows
- Adds a project start screen for the no-images-loaded state
- Adds recent shortcuts for the last opened .annoproj project and last image folder
- Fixes macOS native file-dialog focus behavior after opening/canceling Finder dialogs

## Notes

- Recent project and image folder shortcuts are stored locally with QSettings, not in .annoproj

## Testing

- Requires testing on Windows to verify fluidity for the non-Mac testers

- python -m ruff check src/views/app_window.py src/views/annomate/window.py
- python -m ruff format --check src/views/app_window.py src/views/annomate/window.py
- py_compile syntax check for both edited files