### PR TITLE
Add project start screen

### DIFF
--- a/src/ai_strategies/anomalib_strategy.py
+++ b/src/ai_strategies/anomalib_strategy.py
@@ -595,6 +595,7 @@ class AnomalibStrategy:
                 # score normalization (wrong resize = wrong scores vs threshold).
                 from PIL import Image as _PIL
                 import torchvision.transforms.functional as _TF
+
                 pil_img = _PIL.open(image_path).convert("RGB")
                 transformed = pre.transform(pil_img)
                 if not isinstance(transformed, torch.Tensor):
@@ -604,7 +605,9 @@ class AnomalibStrategy:
                 img = cv2.imread(image_path)
                 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
                 img = cv2.resize(img, (256, 256))
-                tensor = torch.from_numpy(img).permute(2, 0, 1).unsqueeze(0).float() / 255.0
+                tensor = (
+                    torch.from_numpy(img).permute(2, 0, 1).unsqueeze(0).float() / 255.0
+                )
                 tensor = tensor.to(device_obj)
 
             with torch.no_grad():
@@ -612,7 +615,9 @@ class AnomalibStrategy:
 
             score = 0.0
             heatmap = np.zeros((256, 256), dtype=np.float32)
-            postprocessed = False  # True when PostProcessor has already calibrated [0,1]
+            postprocessed = (
+                False  # True when PostProcessor has already calibrated [0,1]
+            )
 
             # Structured anomalib output (InferenceBatch / named fields) — preferred path.
             # The raw model is an anomalib LightningModule whose forward() returns an
@@ -624,7 +629,9 @@ class AnomalibStrategy:
 
             if hasattr(output, "anomaly_map") and output.anomaly_map is not None:
                 heatmap = output.anomaly_map.squeeze().detach().cpu().numpy()
-                postprocessed = True  # map is already calibrated to [0,1] by PostProcessor
+                postprocessed = (
+                    True  # map is already calibrated to [0,1] by PostProcessor
+                )
             elif isinstance(output, tuple):
                 # Fallback for non-anomalib models returning plain tuples.
                 for item in output:
@@ -632,7 +639,9 @@ class AnomalibStrategy:
                         continue
                     if item.ndim >= 2 and item.numel() > 1 and item.is_floating_point():
                         heatmap = item.squeeze().cpu().numpy()
-                    elif item.numel() == 1 and item.is_floating_point() and score == 0.0:
+                    elif (
+                        item.numel() == 1 and item.is_floating_point() and score == 0.0
+                    ):
                         score = float(item.cpu().item())
             elif isinstance(output, torch.Tensor):
                 heatmap = output.squeeze().cpu().numpy()

--- a/src/controllers/inference_controller.py
+++ b/src/controllers/inference_controller.py
@@ -43,7 +43,9 @@ class InferenceWorker(QThread):
         finished (): Emitted once the loop exits, regardless of outcome.
     """
 
-    resultReady = Signal(str, float, object)  # (absolute_path, score: float, score_map: np.ndarray)
+    resultReady = Signal(
+        str, float, object
+    )  # (absolute_path, score: float, score_map: np.ndarray)
     progress = Signal(int)  # count of images processed so far
     finished = Signal()
 
@@ -108,7 +110,9 @@ class InferenceController(QObject):
         batch_done (): Emitted when the current batch finishes.
     """
 
-    result_ready = Signal(str, float, object)  # (path, score: float, score_map: np.ndarray)
+    result_ready = Signal(
+        str, float, object
+    )  # (path, score: float, score_map: np.ndarray)
     progress = Signal(int)  # images processed so far
     batch_done = Signal()  # all images in a batch finished
 

--- a/src/controllers/project_controller.py
+++ b/src/controllers/project_controller.py
@@ -209,7 +209,9 @@ class ProjectController(QObject):
                     "Annotations are loaded but images will not display."
                 )
 
-            calib_state = self._calibration_model._state if self._calibration_model else None
+            calib_state = (
+                self._calibration_model._state if self._calibration_model else None
+            )
             self._project_io.apply_project_to_states(
                 project_data,
                 ds,
@@ -294,7 +296,9 @@ class ProjectController(QObject):
                 sorted(orphaned),
             )
 
-        calib_state = self._calibration_model._state if self._calibration_model else None
+        calib_state = (
+            self._calibration_model._state if self._calibration_model else None
+        )
         path = self._project_io.save_project(
             project_dir=project_dir,
             project_name=project_name,
@@ -322,7 +326,9 @@ class ProjectController(QObject):
             return
         autosave_dir = os.path.join(project_dir, "autosave")
         try:
-            calib_state = self._calibration_model._state if self._calibration_model else None
+            calib_state = (
+                self._calibration_model._state if self._calibration_model else None
+            )
             path = self._project_io.save_project(
                 project_dir=autosave_dir,
                 project_name=f"{self._project_name}.autosave",

--- a/src/core/states/calibration_state.py
+++ b/src/core/states/calibration_state.py
@@ -7,14 +7,14 @@ class CalibrationState:
         self.unit: str = "mm"
         self.calib_p1: tuple | None = None  # (x, y) in original pixels
         self.calib_p2: tuple | None = None  # (x, y) in original pixels
-        self.real_distance: float = 1.0    # known real-world distance
+        self.real_distance: float = 1.0  # known real-world distance
 
         # Grid appearance
         self.grid_visible: bool = False
         self.grid_color: tuple = (58, 90, 122)  # (r, g, b)
-        self.grid_opacity: float = 0.5          # 0.0–1.0
-        self.grid_spacing_world: float = 1.0    # world units per grid step
-        self.grid_spacing_auto: bool = True      # recompute on calibration
+        self.grid_opacity: float = 0.5  # 0.0–1.0
+        self.grid_spacing_world: float = 1.0  # world units per grid step
+        self.grid_spacing_auto: bool = True  # recompute on calibration
 
         # Measurement points — session-only, never persisted
         self.meas_p1: tuple | None = None

--- a/src/core/states/inference_state.py
+++ b/src/core/states/inference_state.py
@@ -22,7 +22,9 @@ class InferenceState:
         """Initialize InferenceState with empty score maps and cache."""
         self.score_maps = {}  # { "img.jpg": np.ndarray }  full heatmap arrays
         self.inference_cache = {}  # { "img.jpg": float }  peak anomaly scores
-        self.scores: dict[str, float] = {}  # { "img.jpg": float }  actual pred_score [0,1]
+        self.scores: dict[
+            str, float
+        ] = {}  # { "img.jpg": float }  actual pred_score [0,1]
         self.labels: dict[str, str] = {}  # { "img.jpg": "ANOMALY" | "NORMAL" }
 
     def clear(self) -> None:

--- a/src/models/calibration_model.py
+++ b/src/models/calibration_model.py
@@ -194,7 +194,7 @@ class CalibrationModel(QObject):
         target_px = 80
         ideal_world = target_px * scale
         exponent = math.floor(math.log10(ideal_world))
-        base = ideal_world / (10 ** exponent)
+        base = ideal_world / (10**exponent)
         if base < 1.5:
             nice = 1
         elif base < 3.5:
@@ -203,4 +203,4 @@ class CalibrationModel(QObject):
             nice = 5
         else:
             nice = 10
-        return nice * (10 ** exponent)
+        return nice * (10**exponent)

--- a/src/models/navigator_model.py
+++ b/src/models/navigator_model.py
@@ -164,7 +164,9 @@ class NavigatorTableModel(QAbstractTableModel):
             count = self._dataset_model.get_annotation_count(row)
             return str(count) if count > 0 else ""
         if col == NavigatorColumns.DECISION:
-            return _DECISION_LABELS.get(self._dataset_model.get_review_decision(row), "")
+            return _DECISION_LABELS.get(
+                self._dataset_model.get_review_decision(row), ""
+            )
         if col == NavigatorColumns.SCORE:
             score = self._score(row)
             return "" if score is None else f"{score:.2f}"
@@ -190,7 +192,9 @@ class NavigatorTableModel(QAbstractTableModel):
         return Qt.AlignLeft | Qt.AlignVCenter
 
     def _font(self, row: int, col: int) -> QFont | None:
-        if col == NavigatorColumns.DECISION and self._dataset_model.get_review_decision(row):
+        if col == NavigatorColumns.DECISION and self._dataset_model.get_review_decision(
+            row
+        ):
             font = QFont()
             font.setBold(True)
             return font

--- a/src/tests/integration/test_data_navigator.py
+++ b/src/tests/integration/test_data_navigator.py
@@ -25,7 +25,9 @@ def navigator(qtbot, tmp_path):
 
 def source_rows(widget):
     return [
-        widget._proxy.mapToSource(widget._proxy.index(row, NavigatorColumns.IMG_ID)).row()
+        widget._proxy.mapToSource(
+            widget._proxy.index(row, NavigatorColumns.IMG_ID)
+        ).row()
         for row in range(widget._proxy.rowCount())
     ]
 

--- a/src/tests/integration/test_viewport_actions.py
+++ b/src/tests/integration/test_viewport_actions.py
@@ -87,7 +87,7 @@ def test_grid_toggle_in_settings_updates_model(canvas, calibrated_model, qtbot):
     qtbot.addWidget(bar)
 
     assert calibrated_model.grid_visible() is True
-    qtbot.mouseClick(bar._grid_chk, Qt.LeftButton)
+    bar._grid_chk.click()
 
     assert calibrated_model.grid_visible() is False
     assert not bar._grid_chk.isChecked()
@@ -125,7 +125,7 @@ def test_center_crop_controls_update_canvas(canvas, calibrated_model, qtbot):
 
     assert not canvas.center_crop_settings()["enabled"]
 
-    qtbot.mouseClick(bar._crop_chk, Qt.LeftButton)
+    bar._crop_chk.click()
     bar._crop_width_spin.setValue(40)
     bar._crop_height_spin.setValue(30)
     bar._crop_shape_combo.setCurrentText("Circle")

--- a/src/tests/model/test_navigator_model.py
+++ b/src/tests/model/test_navigator_model.py
@@ -53,7 +53,9 @@ class TestNavigatorTableModel:
         assert model.data(model.index(0, NavigatorColumns.ANNOTS)) == "1"
         assert model.data(model.index(0, NavigatorColumns.DECISION)) == "Reject"
 
-    def test_inference_values_and_missing_score(self, dataset_model, inference_model, tmp_path):
+    def test_inference_values_and_missing_score(
+        self, dataset_model, inference_model, tmp_path
+    ):
         inference_model.set_score_map(
             str(tmp_path / "a.jpg"), 0.72, np.zeros((2, 2), dtype=np.float32)
         )

--- a/src/tests/unit/test_calibration_model.py
+++ b/src/tests/unit/test_calibration_model.py
@@ -65,15 +65,19 @@ class TestNiceSpacing:
             s = self._spacing(scale)
             # Normalize: divide by the correct power of 10
             exp = math.floor(math.log10(s))
-            mantissa = round(s / (10 ** exp), 6)
-            assert mantissa in (1.0, 2.0, 5.0, 10.0), f"Bad spacing {s} for scale {scale}"
+            mantissa = round(s / (10**exp), 6)
+            assert mantissa in (1.0, 2.0, 5.0, 10.0), (
+                f"Bad spacing {s} for scale {scale}"
+            )
 
     def test_targets_roughly_80px(self):
         # Spacing / scale should be close to 80 original pixels (within 1.25×)
         for scale in [0.01, 0.1, 1.0]:
             s = self._spacing(scale)
             px = s / scale
-            assert 16 <= px <= 800, f"Grid spacing {s} at scale {scale} → {px}px (out of range)"
+            assert 16 <= px <= 800, (
+                f"Grid spacing {s} at scale {scale} → {px}px (out of range)"
+            )
 
 
 class TestMeasurement:

--- a/src/views/annomate/calibration_dialog.py
+++ b/src/views/annomate/calibration_dialog.py
@@ -1,8 +1,13 @@
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
-    QComboBox, QDialogButtonBox, QMessageBox,
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QComboBox,
+    QDialogButtonBox,
+    QMessageBox,
 )
-from PySide6.QtCore import Qt
 
 
 class CalibrationDialog(QDialog):
@@ -24,7 +29,9 @@ class CalibrationDialog(QDialog):
         layout = QVBoxLayout(self)
         layout.setSpacing(10)
 
-        layout.addWidget(QLabel(f"Pixel distance between points: <b>{pixel_dist:.2f} px</b>"))
+        layout.addWidget(
+            QLabel(f"Pixel distance between points: <b>{pixel_dist:.2f} px</b>")
+        )
         layout.addWidget(QLabel("Enter the real-world distance this represents:"))
 
         row = QHBoxLayout()

--- a/src/views/annomate/image_label.py
+++ b/src/views/annomate/image_label.py
@@ -131,7 +131,7 @@ class ImageLabel(QLabel):
         )
 
         # --- Calibration / measure tool state ---
-        self._calib_model = None   # CalibrationModel; set via set_calibration_model()
+        self._calib_model = None  # CalibrationModel; set via set_calibration_model()
         self._pending_calib_pts: list = []  # accumulates up to 2 original-coord tuples
 
     def set_image(self, bgr: np.ndarray, max_display_dim: int = 1200) -> None:
@@ -280,7 +280,10 @@ class ImageLabel(QLabel):
             self._sam_bbox_start = None
             self._sam_bbox_end = None
             self._sam_ghost = None
-        if self.current_tool in (CALIBRATE, MEASURE) and tool_name not in (CALIBRATE, MEASURE):
+        if self.current_tool in (CALIBRATE, MEASURE) and tool_name not in (
+            CALIBRATE,
+            MEASURE,
+        ):
             self._pending_calib_pts = []
             if self._calib_model is not None:
                 self._calib_model.clear_measurement()
@@ -1001,8 +1004,8 @@ class ImageLabel(QLabel):
         # Pending calibration clicks (local state, not yet in model)
         dot_color = QColor(255, 107, 107)
         r = 6.0 / self._zoom
-        pen = QPen(dot_color, 1.5 / self._zoom)
-        text_pen = QPen(dot_color)
+        QPen(dot_color, 1.5 / self._zoom)
+        QPen(dot_color)
         f = painter.font()
         f.setPointSizeF(max(7.0, 9.0 / self._zoom))
         painter.setFont(f)
@@ -1022,8 +1025,14 @@ class ImageLabel(QLabel):
             painter.drawText(QPointF(cx + r + 2.0 / self._zoom, cy - r), label)
 
         if len(pts_to_draw) == 2:
-            p1d = QPointF(pts_to_draw[0][0] * self._base_scale, pts_to_draw[0][1] * self._base_scale)
-            p2d = QPointF(pts_to_draw[1][0] * self._base_scale, pts_to_draw[1][1] * self._base_scale)
+            p1d = QPointF(
+                pts_to_draw[0][0] * self._base_scale,
+                pts_to_draw[0][1] * self._base_scale,
+            )
+            p2d = QPointF(
+                pts_to_draw[1][0] * self._base_scale,
+                pts_to_draw[1][1] * self._base_scale,
+            )
             dash_pen = QPen(dot_color, 1.5 / self._zoom, Qt.DashLine)
             dash_pen.setDashPattern([6, 4])
             painter.setPen(dash_pen)
@@ -1050,8 +1059,12 @@ class ImageLabel(QLabel):
             painter.drawEllipse(QPointF(cx, cy), 1.5 / self._zoom, 1.5 / self._zoom)
 
         if len(meas_pts) == 2:
-            p1d = QPointF(meas_pts[0][0] * self._base_scale, meas_pts[0][1] * self._base_scale)
-            p2d = QPointF(meas_pts[1][0] * self._base_scale, meas_pts[1][1] * self._base_scale)
+            p1d = QPointF(
+                meas_pts[0][0] * self._base_scale, meas_pts[0][1] * self._base_scale
+            )
+            p2d = QPointF(
+                meas_pts[1][0] * self._base_scale, meas_pts[1][1] * self._base_scale
+            )
             painter.setPen(QPen(meas_color, 1.5 / self._zoom))
             painter.setBrush(Qt.NoBrush)
             painter.drawLine(p1d, p2d)
@@ -1066,7 +1079,9 @@ class ImageLabel(QLabel):
                 painter.setPen(QPen(meas_color))
                 painter.drawText(QPointF(mx, my), f"{dist:.3f} {m.unit()}")
         elif len(meas_pts) == 1 and self.current_tool == MEASURE and self._mouse_pos:
-            p1d = QPointF(meas_pts[0][0] * self._base_scale, meas_pts[0][1] * self._base_scale)
+            p1d = QPointF(
+                meas_pts[0][0] * self._base_scale, meas_pts[0][1] * self._base_scale
+            )
             cursor_disp = self.view_to_display(self._mouse_pos)
             dash_pen = QPen(meas_color, 1.0 / self._zoom, Qt.DashLine)
             dash_pen.setDashPattern([4, 4])
@@ -1221,7 +1236,9 @@ class ImageLabel(QLabel):
         w = crop_w * self._base_scale
         h = crop_h * self._base_scale
         crop_rect = QRectF(x, y, w, h)
-        image_rect = QRectF(0, 0, self._display_qpix.width(), self._display_qpix.height())
+        image_rect = QRectF(
+            0, 0, self._display_qpix.width(), self._display_qpix.height()
+        )
 
         outside = QPainterPath()
         outside.setFillRule(Qt.OddEvenFill)

--- a/src/views/annomate/right_panel.py
+++ b/src/views/annomate/right_panel.py
@@ -36,7 +36,11 @@ class RightPanel(QWidget):
     accept_polygons_requested = Signal()
 
     def __init__(
-        self, dataset_model, inference_model=None, calibration_model=None, parent: QWidget = None
+        self,
+        dataset_model,
+        inference_model=None,
+        calibration_model=None,
+        parent: QWidget = None,
     ) -> None:
         super().__init__(parent)
         # Left border separating the panel from the canvas

--- a/src/views/annomate/sections/navigator.py
+++ b/src/views/annomate/sections/navigator.py
@@ -225,7 +225,9 @@ class DataNavigatorSection(QWidget):
         self._selected_row = -1
         if has_images:
             total = self.dataset_model.rowCount()
-            self._lbl_counter.setText(f"{total} image{'s' if total != 1 else ''} loaded")
+            self._lbl_counter.setText(
+                f"{total} image{'s' if total != 1 else ''} loaded"
+            )
         else:
             self._lbl_counter.setText("No images loaded")
         self._sync_visible_columns()
@@ -258,7 +260,10 @@ class DataNavigatorSection(QWidget):
         return proxy_index.row() if proxy_index.isValid() else -1
 
     def _on_column_toggled(self, column: int, checked: bool) -> None:
-        if not checked and self._table.horizontalHeader().sortIndicatorSection() == column:
+        if (
+            not checked
+            and self._table.horizontalHeader().sortIndicatorSection() == column
+        ):
             self._table.sortByColumn(NavigatorColumns.IMG_ID, Qt.AscendingOrder)
         self._sync_visible_columns()
 
@@ -279,15 +284,13 @@ class DataNavigatorSection(QWidget):
         self._table.setColumnHidden(
             NavigatorColumns.SCORE,
             not (
-                self._microsentry_mode
-                and self._column_enabled(NavigatorColumns.SCORE)
+                self._microsentry_mode and self._column_enabled(NavigatorColumns.SCORE)
             ),
         )
         self._table.setColumnHidden(
             NavigatorColumns.CLASS,
             not (
-                self._microsentry_mode
-                and self._column_enabled(NavigatorColumns.CLASS)
+                self._microsentry_mode and self._column_enabled(NavigatorColumns.CLASS)
             ),
         )
 

--- a/src/views/annomate/window.py
+++ b/src/views/annomate/window.py
@@ -7,22 +7,22 @@ Color scheme: no explicit stylesheet colors — Qt platform palette only.
 import logging
 import os
 
-import cv2
 import numpy as np
-from PySide6.QtCore import Qt, QEvent, QPoint, QPointF, Signal
+from PySide6.QtCore import Qt, QEvent, QPoint, QPointF, QTimer, Signal
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QWidget,
     QFrame,
     QVBoxLayout,
+    QLabel,
     QSizePolicy,
     QToolButton,
+    QPushButton,
     QFileDialog,
     QMessageBox,
     QHBoxLayout,
     QComboBox,
     QApplication,
-    QLabel,
 )
 
 from views.annomate._splitter import StyledSplitter
@@ -208,7 +208,9 @@ class _ReviewBar(QFrame):
 
     def mousePressEvent(self, event) -> None:
         handle_rect = self._drag_handle.geometry()
-        if event.button() == Qt.LeftButton and handle_rect.contains(event.position().toPoint()):
+        if event.button() == Qt.LeftButton and handle_rect.contains(
+            event.position().toPoint()
+        ):
             self._dragging = True
             self._drag_start = event.position().toPoint()
             event.accept()
@@ -243,6 +245,158 @@ class _ReviewBar(QFrame):
         self._custom_pos_ratio = (self.x() / max_x, self.y() / max_y)
 
 
+class _ProjectStartScreen(QFrame):
+    """Centered empty-state panel shown before a project or image folder is loaded."""
+
+    new_project_requested = Signal()
+    open_project_requested = Signal()
+    open_image_folder_requested = Signal()
+    open_recent_project_requested = Signal(str)
+    open_recent_image_folder_requested = Signal(str)
+
+    def __init__(self, parent: QWidget = None) -> None:
+        super().__init__(parent)
+        self.setFrameStyle(QFrame.StyledPanel | QFrame.Raised)
+        self.setAutoFillBackground(True)
+        self.setObjectName("ProjectStartScreen")
+        self.setStyleSheet(
+            """
+            QFrame#ProjectStartScreen {
+                border-radius: 10px;
+            }
+            QLabel#ProjectStartTitle {
+                font-size: 22px;
+                font-weight: bold;
+            }
+            QLabel#ProjectStartBody {
+                font-size: 13px;
+            }
+            QPushButton {
+                min-height: 30px;
+                padding-left: 12px;
+                padding-right: 12px;
+            }
+            """
+        )
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 22, 24, 22)
+        layout.setSpacing(12)
+
+        title = QLabel("Start a project")
+        title.setObjectName("ProjectStartTitle")
+        title.setAlignment(Qt.AlignCenter)
+        layout.addWidget(title)
+
+        body = QLabel(
+            "Open an existing .annoproj project, load a folder of images, "
+            "or start a fresh annotation session."
+        )
+        body.setObjectName("ProjectStartBody")
+        body.setAlignment(Qt.AlignCenter)
+        body.setWordWrap(True)
+        layout.addWidget(body)
+
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(8)
+
+        btn_open_project = QPushButton("Open Project")
+        btn_open_project.setToolTip("Open an existing .annoproj project")
+        btn_open_project.clicked.connect(
+            lambda: QTimer.singleShot(0, self.open_project_requested.emit)
+        )
+        btn_row.addWidget(btn_open_project)
+
+        btn_open_images = QPushButton("Open Image Folder")
+        btn_open_images.setToolTip("Load images from a local folder")
+        btn_open_images.clicked.connect(
+            lambda: QTimer.singleShot(0, self.open_image_folder_requested.emit)
+        )
+        btn_row.addWidget(btn_open_images)
+
+        btn_new = QPushButton("New Project")
+        btn_new.setToolTip("Start a new blank project")
+        btn_new.clicked.connect(
+            lambda: QTimer.singleShot(0, self.new_project_requested.emit)
+        )
+        btn_row.addWidget(btn_new)
+
+        layout.addLayout(btn_row)
+
+        self._recent_label = QLabel("Recent")
+        self._recent_label.setObjectName("ProjectStartBody")
+        self._recent_label.setStyleSheet("font-weight: bold;")
+        layout.addWidget(self._recent_label)
+
+        recent_row = QHBoxLayout()
+        recent_row.setSpacing(8)
+
+        self._recent_project_path = ""
+        self._btn_recent_project = QPushButton("Open Last Project")
+        self._btn_recent_project.clicked.connect(self._open_recent_project)
+        recent_row.addWidget(self._btn_recent_project)
+
+        self._recent_image_dir = ""
+        self._btn_recent_images = QPushButton("Open Last Image Folder")
+        self._btn_recent_images.clicked.connect(self._open_recent_images)
+        recent_row.addWidget(self._btn_recent_images)
+
+        layout.addLayout(recent_row)
+        self.set_recent_actions("", "")
+        self.adjustSize()
+
+    def set_recent_actions(self, project_path: str, image_dir: str) -> None:
+        """Show shortcuts to the last opened project and image folder."""
+        self._recent_project_path = project_path or ""
+        self._recent_image_dir = image_dir or ""
+
+        has_project = bool(self._recent_project_path)
+        has_images = bool(self._recent_image_dir)
+        self._recent_label.setVisible(True)
+        self._btn_recent_project.setVisible(True)
+        self._btn_recent_images.setVisible(True)
+        self._btn_recent_project.setEnabled(has_project)
+        self._btn_recent_images.setEnabled(has_images)
+
+        if has_project:
+            name = os.path.basename(self._recent_project_path)
+            self._btn_recent_project.setText(f"Last Project: {name}")
+            self._btn_recent_project.setToolTip(self._recent_project_path)
+        else:
+            self._btn_recent_project.setText("No recent project")
+            self._btn_recent_project.setToolTip(
+                "Open or save a project to show it here."
+            )
+
+        if has_images:
+            name = os.path.basename(os.path.normpath(self._recent_image_dir))
+            self._btn_recent_images.setText(f"Last Image Folder: {name}")
+            self._btn_recent_images.setToolTip(self._recent_image_dir)
+        else:
+            self._btn_recent_images.setText("No recent image folder")
+            self._btn_recent_images.setToolTip("Open an image folder to show it here.")
+
+        self.adjustSize()
+
+    def _open_recent_project(self) -> None:
+        if self._recent_project_path:
+            QTimer.singleShot(
+                0,
+                lambda: self.open_recent_project_requested.emit(
+                    self._recent_project_path
+                ),
+            )
+
+    def _open_recent_images(self) -> None:
+        if self._recent_image_dir:
+            QTimer.singleShot(
+                0,
+                lambda: self.open_recent_image_folder_requested.emit(
+                    self._recent_image_dir
+                ),
+            )
+
+
 class AnnoMateWindow(QWidget):
     """Experimental Photoshop-style layout tab.
 
@@ -254,6 +408,12 @@ class AnnoMateWindow(QWidget):
         io_controller: IOController instance.
         parent: Optional Qt parent widget.
     """
+
+    new_project_requested = Signal()
+    open_project_requested = Signal()
+    open_image_folder_requested = Signal()
+    open_recent_project_requested = Signal(str)
+    open_recent_image_folder_requested = Signal(str)
 
     def __init__(
         self,
@@ -363,6 +523,7 @@ class AnnoMateWindow(QWidget):
 
         self.status_bar = AnnoMateStatusBar(self)
         root.addWidget(self.status_bar)
+        self._set_start_screen_visible(self.dataset_model.rowCount() == 0)
 
     def _build_workspace(self) -> QWidget:
         workspace = QWidget()
@@ -387,6 +548,24 @@ class AnnoMateWindow(QWidget):
             self.canvas, self._calib_model, self.canvas
         )
         self.viewport_actions.raise_()
+
+        self._start_screen = _ProjectStartScreen(self.canvas)
+        self._start_screen.new_project_requested.connect(
+            self.new_project_requested.emit
+        )
+        self._start_screen.open_project_requested.connect(
+            self.open_project_requested.emit
+        )
+        self._start_screen.open_image_folder_requested.connect(
+            self.open_image_folder_requested.emit
+        )
+        self._start_screen.open_recent_project_requested.connect(
+            self.open_recent_project_requested.emit
+        )
+        self._start_screen.open_recent_image_folder_requested.connect(
+            self.open_recent_image_folder_requested.emit
+        )
+        self._start_screen.raise_()
 
         self._review_bar = _ReviewBar(self.canvas, self.canvas)
         self._review_bar.decision_changed.connect(self._on_review_decision)
@@ -416,12 +595,37 @@ class AnnoMateWindow(QWidget):
         super().showEvent(event)
         self.viewport_actions.reposition(self.canvas.size())
         self._review_bar.reposition(self.canvas.size())
+        self._reposition_start_screen()
 
     def eventFilter(self, obj, event) -> bool:
         if obj is self.canvas and event.type() == QEvent.Resize:
             self.viewport_actions.reposition(event.size())
             self._review_bar.reposition(event.size())
+            self._reposition_start_screen()
         return super().eventFilter(obj, event)
+
+    def _set_start_screen_visible(self, visible: bool) -> None:
+        """Show the project start panel only while no dataset is loaded."""
+        self._start_screen.setVisible(visible)
+        if visible:
+            self._start_screen.raise_()
+            self._reposition_start_screen()
+
+    def set_project_start_state(self, last_project: str, last_image_dir: str) -> None:
+        """Update start-screen recent actions."""
+        self._start_screen.set_recent_actions(last_project, last_image_dir)
+        self._reposition_start_screen()
+
+    def _reposition_start_screen(self) -> None:
+        """Keep the empty-state panel centered in the canvas area."""
+        if not hasattr(self, "_start_screen"):
+            return
+        width = min(520, max(360, self.canvas.width() - 80))
+        self._start_screen.setFixedWidth(width)
+        self._start_screen.adjustSize()
+        x = max(0, (self.canvas.width() - self._start_screen.width()) // 2)
+        y = max(24, (self.canvas.height() - self._start_screen.height()) // 2)
+        self._start_screen.move(x, y)
 
     # ------------------------------------------------------------------ #
     # Navigation slots
@@ -443,11 +647,13 @@ class AnnoMateWindow(QWidget):
             self.canvas.clear_image()
             self.right_panel.set_current_row(-1)
             self.status_bar.set_class("")
+            self._set_start_screen_visible(True)
 
     def _load_row(self, row: int) -> None:
         bgr = self.io_controller.load_image_for_display(row)
         if bgr is None:
             return
+        self._set_start_screen_visible(False)
         self._current_bgr = bgr
         self._current_row = row
         self._review_bar.set_decision(self.dataset_model.get_review_decision(row))
@@ -529,6 +735,7 @@ class AnnoMateWindow(QWidget):
         import math
         from views.annomate.calibration_dialog import CalibrationDialog
         from PySide6.QtWidgets import QDialog
+
         if self._calib_model is None:
             return
         pixel_dist = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
@@ -538,7 +745,9 @@ class AnnoMateWindow(QWidget):
             self._calib_model.set_calib_points(p1, p2)
             ok = self._calib_model.apply_calibration(real_dist, unit)
             if not ok:
-                QMessageBox.warning(self, "Calibration", "The two points are too close together.")
+                QMessageBox.warning(
+                    self, "Calibration", "The two points are too close together."
+                )
         self.canvas.set_tool(None)  # clears _pending_calib_pts, resets cursor
         self.tool_palette.deselect_all()
         self.viewport_actions.set_active_tool("")

--- a/src/views/annomate/window.py
+++ b/src/views/annomate/window.py
@@ -314,13 +314,6 @@ class _ProjectStartScreen(QFrame):
         )
         btn_row.addWidget(btn_open_images)
 
-        btn_new = QPushButton("New Project")
-        btn_new.setToolTip("Start a new blank project")
-        btn_new.clicked.connect(
-            lambda: QTimer.singleShot(0, self.new_project_requested.emit)
-        )
-        btn_row.addWidget(btn_new)
-
         layout.addLayout(btn_row)
 
         self._recent_label = QLabel("Recent")

--- a/src/views/app_window.py
+++ b/src/views/app_window.py
@@ -5,6 +5,7 @@ See MVC.md § Architecture Rules for the full layer contract.
 
 import os
 
+from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import (
     QMainWindow,
     QInputDialog,
@@ -17,6 +18,8 @@ from views.validation.window import ValidationWindow
 from views.annomate.window import AnnoMateWindow
 
 _APP_TITLE = "AnnoMate & MicroSentryAI"
+_LAST_IMAGE_DIR_KEY = "recent/last_image_dir"
+_LAST_PROJECT_KEY = "recent/last_project"
 
 
 class AppWindow(QMainWindow):
@@ -59,15 +62,30 @@ class AppWindow(QMainWindow):
         self.validation_controller = validation_controller
         self.project_controller = project_controller
         self.calibration_model = calibration_model
+        self._settings = QSettings("LANL", "AnnoMateMicroSentryAI")
 
         # Sub-views
         self.validation_view = ValidationWindow(validation_model, validation_controller)
         self.validation_view.setWindowTitle("Validation")
         self.validation_view.resize(900, 650)
         self.annomate_view = AnnoMateWindow(
-            dataset_model, io_controller, inference_model, inference_controller,
+            dataset_model,
+            io_controller,
+            inference_model,
+            inference_controller,
             calibration_model=calibration_model,
         )
+
+        self.annomate_view.new_project_requested.connect(self._new_project)
+        self.annomate_view.open_project_requested.connect(self._open_project)
+        self.annomate_view.open_image_folder_requested.connect(self._open_image_folder)
+        self.annomate_view.open_recent_project_requested.connect(
+            self._open_recent_project
+        )
+        self.annomate_view.open_recent_image_folder_requested.connect(
+            self._open_recent_image_folder
+        )
+        self._refresh_project_start_state()
 
         self.setCentralWidget(self.annomate_view)
 
@@ -126,6 +144,80 @@ class AppWindow(QMainWindow):
         self._ms_action.setToolTip("Toggle MicroSentryAI heatmap and segmentation")
         self._ms_action.toggled.connect(self.annomate_view._on_microsentry_toggled)
         view_menu.addAction(self._ms_action)
+
+    def _refresh_project_start_state(self) -> None:
+        """Refresh recent-action shortcuts on the empty project start screen."""
+        self.annomate_view.set_project_start_state(
+            self._last_project(), self._last_image_dir()
+        )
+
+    def _remember_recent_project(self, path: str) -> None:
+        if path:
+            self._settings.setValue(_LAST_PROJECT_KEY, path)
+
+    def _remember_recent_image_dir(self, path: str) -> None:
+        if path:
+            self._settings.setValue(_LAST_IMAGE_DIR_KEY, path)
+
+    def _last_project(self) -> str:
+        return self._settings.value(_LAST_PROJECT_KEY, "", type=str) or ""
+
+    def _last_image_dir(self) -> str:
+        return self._settings.value(_LAST_IMAGE_DIR_KEY, "", type=str) or ""
+
+    def _open_project_path(self, path: str) -> None:
+        try:
+            project_data, warnings = self.project_controller.open_project(path)
+        except Exception as exc:
+            QMessageBox.critical(
+                self, "Open Project", f"Could not read project:\n{exc}"
+            )
+            return
+
+        if warnings:
+            QMessageBox.warning(self, "Open Project", "\n\n".join(warnings))
+
+        model_path = project_data.get("inference", {}).get("model_path", "")
+        self.annomate_view.set_saved_model_path(model_path)
+        if model_path and not self.inference_controller.has_model():
+            self.statusBar().showMessage(
+                f"Previous model saved: {os.path.basename(model_path)} — use 'Load Previous' in the MicroSentryAI panel.",
+                8000,
+            )
+
+        self._remember_recent_project(path)
+        image_dir = project_data.get("dataset", {}).get("image_dir", "")
+        if image_dir:
+            self._remember_recent_image_dir(image_dir)
+        self._refresh_project_start_state()
+
+    def _open_recent_project(self, path: str) -> None:
+        if self.project_controller.is_dirty and not self._confirm_discard():
+            return
+        if not os.path.exists(path):
+            self._settings.remove(_LAST_PROJECT_KEY)
+            self._refresh_project_start_state()
+            QMessageBox.warning(
+                self,
+                "Open Project",
+                f"Recent project no longer exists:\n{path}",
+            )
+            return
+        self._open_project_path(path)
+
+    def _open_recent_image_folder(self, directory: str) -> None:
+        if not os.path.isdir(directory):
+            self._settings.remove(_LAST_IMAGE_DIR_KEY)
+            self._refresh_project_start_state()
+            QMessageBox.warning(
+                self,
+                "Open Image Folder",
+                f"Recent image folder no longer exists:\n{directory}",
+            )
+            return
+        self.io_controller.load_folder(directory)
+        self._remember_recent_image_dir(directory)
+        self._refresh_project_start_state()
 
     # ================================================================== #
     # Project slots
@@ -209,9 +301,15 @@ class AppWindow(QMainWindow):
             if reply != QMessageBox.Ok:
                 return
         try:
-            save_fn()
+            saved_path = save_fn()
         except Exception as exc:
             QMessageBox.critical(self, "Save Project", f"Could not save:\n{exc}")
+            return
+        self._remember_recent_project(saved_path)
+        image_dir = self.dataset_model.get_image_dir()
+        if image_dir:
+            self._remember_recent_image_dir(image_dir)
+        self._refresh_project_start_state()
 
     def _open_image_folder(self) -> None:
         """Scan a folder for images and load them as the current dataset."""
@@ -231,6 +329,8 @@ class AppWindow(QMainWindow):
             return
         try:
             self.project_controller.relocate_images(new_dir)
+            self._remember_recent_image_dir(new_dir)
+            self._refresh_project_start_state()
         except Exception as exc:
             QMessageBox.critical(
                 self, "Relocate Images", f"Could not scan folder:\n{exc}"


### PR DESCRIPTION
## Summary

Adds a project start screen for the empty/no-images-loaded state so users have clear first actions when launching the tool.

## Changes

- Adds a centered start screen with Open Project and Open Image Folder actions
- Shows recent project and recent image folder shortcuts after those paths have been used
- Stores recent shortcuts locally with QSettings
- Hides the start screen once an image dataset is loaded and restores it when the dataset is cleared
- Applies Ruff cleanup needed because CI runs pre-commit across all files
- Stabilizes viewport action toggle tests that were already failing on clean upstream/staging

## Notes

- This PR only covers the project start screen slice from the earlier combined workflow PR
- Recent shortcuts are local app convenience state, not .annoproj project state
- The viewport test fix is included because the same failures reproduced on clean upstream/staging, not because the start screen introduced them

## Testing

- python -m pytest src/tests/integration/test_viewport_actions.py -q
- python -m ruff check src/tests/integration/test_viewport_actions.py
- python -m ruff format --check src/tests/integration/test_viewport_actions.py
- CI checks passed