### PR TITLE
Remember opened image folders on the project start screen

### DIFF
--- a/src/views/app_window.py
+++ b/src/views/app_window.py
@@ -338,6 +338,8 @@ class AppWindow(QMainWindow):
         if not directory:
             return
         self.io_controller.load_folder(directory)
+        self._remember_recent_image_dir(directory)
+        self._refresh_project_start_state()
 
     def _relocate_images(self) -> None:
         """Point to a new image directory without clearing annotations."""


### PR DESCRIPTION
## Summary

Fixes the project start screen so a folder selected through 'Open Image Folder' is available as the recent image-folder shortcut on future empty-state visits.

## Changes

- Stores the selected folder in local 'QSettings' after 'Open Image Folder' succeeds
- Refreshes the start-screen recent actions immediately after loading a folder

## Files Changed

- src/views/app_window.py

## Notes

- This is a small follow-up to the merged project start-screen work
- Recent folder state remains local app convenience state, not .annoproj project state
- This does not include broad Ruff/pre-commit formatting changes

## Testing

- python -m ruff check src/views/app_window.py
- python -m py_compile src/views/app_window.py
- Manual macOS test: open an image folder, return to an empty/new project state, and confirm the recent image-folder shortcut appears