### PR TITLE
Moved and added settings to a collapsible top bar

### DIFF
--- a/src/core/logic/center_template.py
+++ b/src/core/logic/center_template.py
@@ -15,9 +15,7 @@ def locate_center(
     """
     img_gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if image.ndim == 3 else image
     tpl_gray = (
-        cv2.cvtColor(template, cv2.COLOR_BGR2GRAY)
-        if template.ndim == 3
-        else template
+        cv2.cvtColor(template, cv2.COLOR_BGR2GRAY) if template.ndim == 3 else template
     )
     result = cv2.matchTemplate(img_gray, tpl_gray, cv2.TM_CCOEFF_NORMED)
     _, max_val, _, max_loc = cv2.minMaxLoc(result)

--- a/src/core/persistence/project_io.py
+++ b/src/core/persistence/project_io.py
@@ -360,9 +360,7 @@ class ProjectIO:
             )
             calibration_state.real_distance = cdata.get("real_distance", 1.0)
             calibration_state.grid_visible = (
-                True
-                if using_default_pixel_scale
-                else cdata.get("grid_visible", True)
+                True if using_default_pixel_scale else cdata.get("grid_visible", True)
             )
             color = cdata.get("grid_color", [58, 90, 122])
             calibration_state.grid_color = tuple(color)

--- a/src/models/annotations_model.py
+++ b/src/models/annotations_model.py
@@ -100,7 +100,9 @@ class AnnotationTableModel(QAbstractTableModel):
 
         return None
 
-    def setData(self, index: QModelIndex, value: object, role: int = Qt.EditRole) -> bool:
+    def setData(
+        self, index: QModelIndex, value: object, role: int = Qt.EditRole
+    ) -> bool:
         if (
             role != Qt.EditRole
             or not index.isValid()
@@ -115,7 +117,9 @@ class AnnotationTableModel(QAbstractTableModel):
             return False
         if self._annotations[annotation_idx]["category_name"] == name:
             return False
-        self._dataset_model.update_annotation_class(self._current_row, annotation_idx, name)
+        self._dataset_model.update_annotation_class(
+            self._current_row, annotation_idx, name
+        )
         return True
 
     def set_current_row(self, row: int) -> None:
@@ -141,7 +145,9 @@ class AnnotationTableModel(QAbstractTableModel):
             return None
         annotation = self._annotations[row]
         if col == AnnotationColumns.COLOR:
-            return tuple(self._dataset_model.get_class_color(annotation["category_name"]))
+            return tuple(
+                self._dataset_model.get_class_color(annotation["category_name"])
+            )
         if col == AnnotationColumns.CLASS:
             return annotation["category_name"].casefold()
         if col == AnnotationColumns.VERTICES:

--- a/src/models/calibration_model.py
+++ b/src/models/calibration_model.py
@@ -190,7 +190,9 @@ class CalibrationModel(QObject):
         p2 = data.get("calib_p2")
         s.calib_p2 = tuple(p2) if p2 and not using_default_pixel_scale else None
         s.real_distance = data.get("real_distance", 1.0)
-        s.grid_visible = True if using_default_pixel_scale else data.get("grid_visible", True)
+        s.grid_visible = (
+            True if using_default_pixel_scale else data.get("grid_visible", True)
+        )
         color = data.get("grid_color", [58, 90, 122])
         s.grid_color = tuple(color)
         s.grid_opacity = data.get("grid_opacity", 0.5)

--- a/src/tests/integration/test_annotations_section.py
+++ b/src/tests/integration/test_annotations_section.py
@@ -72,7 +72,9 @@ def test_clicking_sorted_annotation_emits_source_index(annotations_section, qtbo
     assert widget._selected_idx == 2
 
 
-def test_deleting_annotation_after_sort_targets_source_index(annotations_section, qtbot):
+def test_deleting_annotation_after_sort_targets_source_index(
+    annotations_section, qtbot
+):
     widget, model = annotations_section
     widget._proxy.sort(AnnotationColumns.CLASS, Qt.AscendingOrder)
     index = _proxy_index_for_annotation(widget, 0, AnnotationColumns.DELETE)
@@ -105,7 +107,9 @@ def test_annotations_table_expands_to_show_all_rows(annotations_section, qtbot):
     widget, model = annotations_section
 
     assert widget._table.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
-    last_index = widget._proxy.index(widget._proxy.rowCount() - 1, AnnotationColumns.CLASS)
+    last_index = widget._proxy.index(
+        widget._proxy.rowCount() - 1, AnnotationColumns.CLASS
+    )
     assert (
         widget._table.visualRect(last_index).bottom()
         < widget._table.viewport().height()
@@ -115,7 +119,9 @@ def test_annotations_table_expands_to_show_all_rows(annotations_section, qtbot):
     model.add_annotation(0, "Crack", [(0, 0), (1, 0), (1, 1)])
     qtbot.wait(50)
 
-    last_index = widget._proxy.index(widget._proxy.rowCount() - 1, AnnotationColumns.CLASS)
+    last_index = widget._proxy.index(
+        widget._proxy.rowCount() - 1, AnnotationColumns.CLASS
+    )
     assert widget._table.height() > old_height
     assert (
         widget._table.visualRect(last_index).bottom()

--- a/src/tests/integration/test_sam_canvas.py
+++ b/src/tests/integration/test_sam_canvas.py
@@ -33,12 +33,12 @@ def test_sam_tool_sets_crosscursor(canvas):
 
 def test_polygon_tool_does_not_affect_sam_state(canvas):
     canvas.set_tool(SAM_BBOX)
-    canvas._sam_bbox_start = QPointF(10, 10)
-    canvas._sam_bbox_end = QPointF(50, 50)
+    canvas._shape_start = QPointF(10, 10)
+    canvas._shape_end = QPointF(50, 50)
     # Switching to polygon should clear SAM state
     canvas.set_tool(POLYGON)
-    assert canvas._sam_bbox_start is None
-    assert canvas._sam_bbox_end is None
+    assert canvas._shape_start is None
+    assert canvas._shape_end is None
     assert canvas._sam_ghost is None
 
 
@@ -64,12 +64,12 @@ def test_set_sam_ghost_empty_pts_clears_ghost(canvas):
 
 def test_clear_sam_ghost_clears_all_state(canvas):
     canvas.set_sam_ghost([(0, 0), (10, 0), (10, 10)], 0.9)
-    canvas._sam_bbox_start = QPointF(5, 5)
-    canvas._sam_bbox_end = QPointF(20, 20)
+    canvas._shape_start = QPointF(5, 5)
+    canvas._shape_end = QPointF(20, 20)
     canvas.clear_sam_ghost()
     assert canvas._sam_ghost is None
-    assert canvas._sam_bbox_start is None
-    assert canvas._sam_bbox_end is None
+    assert canvas._shape_start is None
+    assert canvas._shape_end is None
 
 
 # ---------------------------------------------------------------------------
@@ -100,8 +100,8 @@ def test_accept_sam_ghost_clears_state(canvas):
     canvas.set_sam_ghost([(0, 0), (10, 0), (10, 10)], 0.5)
     canvas.accept_sam_ghost()
     assert canvas._sam_ghost is None
-    assert canvas._sam_bbox_start is None
-    assert canvas._sam_bbox_end is None
+    assert canvas._shape_start is None
+    assert canvas._shape_end is None
 
 
 def test_accept_sam_ghost_returns_false_when_no_ghost(canvas):

--- a/src/tests/model/test_annotations_model.py
+++ b/src/tests/model/test_annotations_model.py
@@ -21,9 +21,7 @@ def _make_model():
     dataset_model.load_folder("/fake", ["one.jpg"])
     dataset_model.add_annotation(0, "Beta", [(0, 0), (1, 0), (1, 1)])
     dataset_model.add_annotation(0, "alpha", [(0, 0), (2, 0), (2, 2), (0, 2)])
-    dataset_model.add_annotation(
-        0, "Gamma", [(0, 0), (3, 0), (3, 3), (1, 4), (0, 3)]
-    )
+    dataset_model.add_annotation(0, "Gamma", [(0, 0), (3, 0), (3, 3), (1, 4), (0, 3)])
     return dataset_model
 
 
@@ -57,8 +55,7 @@ def test_visibility_column_reflects_annotation_state():
     dataset_model.set_annotation_visible(0, 0, False)
 
     assert (
-        table_model.index(0, AnnotationColumns.VISIBILITY).data(VISIBLE_ROLE)
-        is False
+        table_model.index(0, AnnotationColumns.VISIBILITY).data(VISIBLE_ROLE) is False
     )
     assert (
         table_model.index(0, AnnotationColumns.VISIBILITY).data(Qt.DisplayRole)
@@ -129,9 +126,7 @@ def test_area_rounds_to_whole_numbers_before_scientific_notation():
     dataset_model = DatasetTableModel(DatasetState())
     dataset_model.add_class("Beta", (20, 20, 20))
     dataset_model.load_folder("/fake", ["one.jpg"])
-    dataset_model.add_annotation(
-        0, "Beta", [(0, 0), (123456, 0), (123456, 1), (0, 1)]
-    )
+    dataset_model.add_annotation(0, "Beta", [(0, 0), (123456, 0), (123456, 1), (0, 1)])
     table_model = AnnotationTableModel(dataset_model)
     table_model.set_current_row(0)
 

--- a/src/views/annomate/canvas_toolbar.py
+++ b/src/views/annomate/canvas_toolbar.py
@@ -1,0 +1,170 @@
+"""
+CanvasToolbar — Collapsible top bar for the picture canvas.
+Provides context-sensitive controls for Polygon shapes, SAM variations, and edit settings.
+"""
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import (
+    QFrame, QHBoxLayout, QVBoxLayout, QLabel, QComboBox, QSlider, QWidget, QPushButton
+)
+
+_SAM_VARIANT_MAP = {
+    "SAM2.1 Tiny": "sam2_t.pt",
+    "SAM2.1 Small": "sam2_s.pt",
+    "SAM2.1 Base+": "sam2_b.pt",
+    "SAM2.1 Large": "sam2_l.pt",
+}
+
+class CanvasToolbar(QFrame):
+    thickness_changed = Signal(float)
+    shape_changed = Signal(str)
+    sam_variant_changed = Signal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setFrameStyle(QFrame.StyledPanel | QFrame.Raised)
+        self.setAutoFillBackground(True)
+
+        self.setStyleSheet("""
+            QFrame {
+                background: palette(window);
+                border-bottom: 1px solid palette(mid);
+            }
+        """)
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.setSpacing(0)
+
+        # Top bar (Toggle handle)
+        self._top_bar = QWidget()
+        top_layout = QHBoxLayout(self._top_bar)
+        top_layout.setContentsMargins(4, 2, 4, 2)
+        
+        self._btn_toggle = QPushButton("Settings (None)")
+        self._btn_toggle.setFlat(True)
+        self._btn_toggle.setCheckable(True)
+        self._btn_toggle.setChecked(True)
+        self._btn_toggle.clicked.connect(self._on_toggle)
+        self._btn_toggle.setStyleSheet("font-weight: bold; text-align: left;")
+        self._btn_toggle.setEnabled(False)
+        top_layout.addWidget(self._btn_toggle)
+        top_layout.addStretch()
+
+        main_layout.addWidget(self._top_bar)
+
+        # Bottom container (Collapsible content)
+        self._content = QWidget()
+        content_layout = QHBoxLayout(self._content)
+        content_layout.setContentsMargins(8, 4, 8, 4)
+        content_layout.setSpacing(12)
+
+        # Mode / Shape
+        self._lbl_mode = QLabel("Shape Mode:")
+        self._combo_shape = QComboBox()
+        self._combo_shape.currentTextChanged.connect(self._on_shape_changed)
+        content_layout.addWidget(self._lbl_mode)
+        content_layout.addWidget(self._combo_shape)
+
+        # Thickness
+        self._lbl_thickness = QLabel("Brush Thickness:")
+        self._slider_thickness = QSlider(Qt.Horizontal)
+        self._slider_thickness.setRange(1, 40)
+        self._slider_thickness.setTickPosition(QSlider.TickPosition.TicksBelow)
+        self._slider_thickness.setTickInterval(4)
+        self._slider_thickness.setFixedWidth(150)
+        self._slider_thickness.valueChanged.connect(self._on_thickness_changed)
+        self._lbl_thickness_val = QLabel("2.00 px")
+        self._lbl_thickness_val.setFixedWidth(55)
+        content_layout.addWidget(self._lbl_thickness)
+        content_layout.addWidget(self._slider_thickness)
+        content_layout.addWidget(self._lbl_thickness_val)
+
+        # SAM specific
+        self._lbl_sam = QLabel("SAM Variant:")
+        self._combo_sam = QComboBox()
+        self._combo_sam.addItems(list(_SAM_VARIANT_MAP.keys()))
+        self._combo_sam.currentTextChanged.connect(self._on_sam_changed)
+        self._lbl_sam_status = QLabel("Ready")
+        content_layout.addWidget(self._lbl_sam)
+        content_layout.addWidget(self._combo_sam)
+        content_layout.addWidget(self._lbl_sam_status)
+
+        content_layout.addStretch()
+        main_layout.addWidget(self._content)
+
+        self._context = ""
+        self.set_context("")
+
+    def _on_toggle(self, checked: bool):
+        self._content.setVisible(checked)
+        self._btn_toggle.setText("▾ Settings" if checked else "▸ Settings")
+
+    def _on_shape_changed(self, text: str):
+        mapping = {
+            "Point-by-point": "point",
+            "Free Brush": "brush",
+            "Rectangle": "rectangle",
+            "Circle": "circle"
+        }
+        self.shape_changed.emit(mapping.get(text, "point"))
+
+    def _on_thickness_changed(self, val: int):
+        thickness = val * 0.25
+        self._lbl_thickness_val.setText(f"{thickness:.2f} px")
+        self.thickness_changed.emit(thickness)
+
+    def _on_sam_changed(self, text: str):
+        self.sam_variant_changed.emit(_SAM_VARIANT_MAP.get(text, "sam2_t.pt"))
+
+    def current_sam_variant(self) -> str:
+        return _SAM_VARIANT_MAP.get(self._combo_sam.currentText(), "sam2_t.pt")
+
+    def set_sam_status(self, status: str, color: str):
+        self._lbl_sam_status.setText(status)
+        self._lbl_sam_status.setStyleSheet(f"color: {color}; font-style: {'italic' if color == 'grey' else 'normal'};")
+
+    def set_context(self, context: str, thickness: float = 2.0):
+        """Update toolbar state based on selected canvas context."""
+        self._context = context
+        if context == "":
+            self._btn_toggle.setEnabled(False)
+            self._content.setVisible(False)
+            self._btn_toggle.setText("Settings (None)")
+            return
+
+        self._btn_toggle.setEnabled(True)
+        self._btn_toggle.setText("▾ Settings" if self._btn_toggle.isChecked() else "▸ Settings")
+        self._content.setVisible(self._btn_toggle.isChecked())
+
+        self._combo_shape.blockSignals(True)
+        self._combo_shape.clear()
+
+        show_shape = context in ("polygon", "sam_bbox")
+        show_thickness = context in ("polygon", "edit", "sam_bbox")
+        show_sam = context == "sam_bbox"
+
+        self._lbl_mode.setVisible(show_shape)
+        self._combo_shape.setVisible(show_shape)
+
+        self._lbl_thickness.setVisible(show_thickness)
+        self._slider_thickness.setVisible(show_thickness)
+        self._lbl_thickness_val.setVisible(show_thickness)
+
+        self._lbl_sam.setVisible(show_sam)
+        self._combo_sam.setVisible(show_sam)
+        self._lbl_sam_status.setVisible(show_sam)
+
+        if context in ("polygon", "sam_bbox"):
+            self._combo_shape.addItems(["Point-by-point", "Free Brush", "Rectangle", "Circle"])
+
+        self._combo_shape.blockSignals(False)
+
+        if show_thickness:
+            self._slider_thickness.blockSignals(True)
+            self._slider_thickness.setValue(int(thickness * 4))
+            self._lbl_thickness_val.setText(f"{thickness:.2f} px")
+            self._slider_thickness.blockSignals(False)
+
+        if show_shape:
+            self._on_shape_changed(self._combo_shape.currentText())

--- a/src/views/annomate/canvas_toolbar.py
+++ b/src/views/annomate/canvas_toolbar.py
@@ -5,7 +5,14 @@ Provides context-sensitive controls for Polygon shapes, SAM variations, and edit
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QFrame, QHBoxLayout, QVBoxLayout, QLabel, QComboBox, QSlider, QWidget, QPushButton
+    QFrame,
+    QHBoxLayout,
+    QVBoxLayout,
+    QLabel,
+    QComboBox,
+    QSlider,
+    QWidget,
+    QPushButton,
 )
 
 _SAM_VARIANT_MAP = {
@@ -14,6 +21,7 @@ _SAM_VARIANT_MAP = {
     "SAM2.1 Base+": "sam2_b.pt",
     "SAM2.1 Large": "sam2_l.pt",
 }
+
 
 class CanvasToolbar(QFrame):
     thickness_changed = Signal(float)
@@ -40,7 +48,7 @@ class CanvasToolbar(QFrame):
         self._top_bar = QWidget()
         top_layout = QHBoxLayout(self._top_bar)
         top_layout.setContentsMargins(4, 2, 4, 2)
-        
+
         self._btn_toggle = QPushButton("Settings (None)")
         self._btn_toggle.setFlat(True)
         self._btn_toggle.setCheckable(True)
@@ -105,7 +113,7 @@ class CanvasToolbar(QFrame):
             "Point-by-point": "point",
             "Free Brush": "brush",
             "Rectangle": "rectangle",
-            "Circle": "circle"
+            "Circle": "circle",
         }
         self.shape_changed.emit(mapping.get(text, "point"))
 
@@ -122,7 +130,9 @@ class CanvasToolbar(QFrame):
 
     def set_sam_status(self, status: str, color: str):
         self._lbl_sam_status.setText(status)
-        self._lbl_sam_status.setStyleSheet(f"color: {color}; font-style: {'italic' if color == 'grey' else 'normal'};")
+        self._lbl_sam_status.setStyleSheet(
+            f"color: {color}; font-style: {'italic' if color == 'grey' else 'normal'};"
+        )
 
     def set_context(self, context: str, thickness: float = 2.0):
         """Update toolbar state based on selected canvas context."""
@@ -134,7 +144,9 @@ class CanvasToolbar(QFrame):
             return
 
         self._btn_toggle.setEnabled(True)
-        self._btn_toggle.setText("▾ Settings" if self._btn_toggle.isChecked() else "▸ Settings")
+        self._btn_toggle.setText(
+            "▾ Settings" if self._btn_toggle.isChecked() else "▸ Settings"
+        )
         self._content.setVisible(self._btn_toggle.isChecked())
 
         self._combo_shape.blockSignals(True)
@@ -156,7 +168,9 @@ class CanvasToolbar(QFrame):
         self._lbl_sam_status.setVisible(show_sam)
 
         if context in ("polygon", "sam_bbox"):
-            self._combo_shape.addItems(["Point-by-point", "Free Brush", "Rectangle", "Circle"])
+            self._combo_shape.addItems(
+                ["Point-by-point", "Free Brush", "Rectangle", "Circle"]
+            )
 
         self._combo_shape.blockSignals(False)
 

--- a/src/views/annomate/image_label.py
+++ b/src/views/annomate/image_label.py
@@ -29,6 +29,7 @@ from PySide6.QtGui import (
     QPainterPath,
 )
 from PySide6.QtWidgets import QLabel, QSizePolicy
+from core.utils.geometry import simplify_polygon
 
 logger = logging.getLogger("AnnoMate.ImageLabel")
 
@@ -93,6 +94,9 @@ class ImageLabel(QLabel):
         self.current_tool: Optional[str] = None
         self._active_color = QColor(0, 200, 0)
         self._line_thickness = 2.0
+        self._draw_shape = "point"
+        self._shape_state: Optional[QPointF] = None
+        self._shape_end: Optional[QPointF] = None
 
         self._orig_image_bgr: Optional[np.ndarray] = None
         self._display_qpix: Optional[QPixmap] = None
@@ -130,8 +134,6 @@ class ImageLabel(QLabel):
         self._selected_ai_idx: int = -1
 
         # --- SAM tool state (display coords) ---
-        self._sam_bbox_start: Optional[QPointF] = None
-        self._sam_bbox_end: Optional[QPointF] = None
         self._sam_ghost: Optional[Tuple[List[QPointF], float]] = (
             None  # (display_pts, confidence)
         )
@@ -269,6 +271,8 @@ class ImageLabel(QLabel):
         self._center_crop_calibrating = False
         self._dragging_center_crop = False
         self.current_polygon_points.clear()
+        self._shape_start = None
+        self._shape_end = None
         self._overlays = []
         self._ai_overlays = []
         self.selected_polygon_idx = -1
@@ -276,8 +280,6 @@ class ImageLabel(QLabel):
         self._dragging_vertex_idx = -1
         self._dragging_vertex_poly = -1
         self._selected_ai_idx = -1
-        self._sam_bbox_start = None
-        self._sam_bbox_end = None
         self._sam_ghost = None
         self.update()
 
@@ -289,8 +291,6 @@ class ImageLabel(QLabel):
                 ``"sam_bbox"``, ``"calibrate"``, ``"measure"``, or ``None``.
         """
         if self.current_tool == SAM_BBOX and tool_name != SAM_BBOX:
-            self._sam_bbox_start = None
-            self._sam_bbox_end = None
             self._sam_ghost = None
         if self.current_tool in (CALIBRATE, MEASURE) and tool_name not in (
             CALIBRATE,
@@ -304,6 +304,10 @@ class ImageLabel(QLabel):
             self.setCursor(Qt.CrossCursor)
         elif tool_name is None:
             self.setCursor(Qt.ArrowCursor)
+
+    def set_draw_shape(self, shape: str) -> None:
+        """Set drawing sub-mode: 'point', 'brush', 'rectangle', 'circle'."""
+        self._draw_shape = shape
 
     def set_active_color(self, color: QColor) -> None:
         """Set the stroke color used when drawing a new polygon.
@@ -497,6 +501,8 @@ class ImageLabel(QLabel):
     def clear_current_polygon(self) -> None:
         """Discard all in-progress polygon vertices and repaint."""
         self.current_polygon_points.clear()
+        self._shape_start = None
+        self._shape_end = None
         self.update()
 
     # ------------------------------------------------------------------ #
@@ -533,8 +539,6 @@ class ImageLabel(QLabel):
     def clear_sam_ghost(self) -> None:
         """Discard the SAM ghost polygon, bbox, and repaint."""
         self._sam_ghost = None
-        self._sam_bbox_start = None
-        self._sam_bbox_end = None
         self.update()
 
     def accept_sam_ghost(self) -> bool:
@@ -552,9 +556,8 @@ class ImageLabel(QLabel):
         pts_disp, _ = self._sam_ghost
         pts_orig = [self.display_to_original(p) for p in pts_disp]
         self._sam_ghost = None
-        self._sam_bbox_start = None
-        self._sam_bbox_end = None
-        self.polygonFinished.emit(pts_orig)
+        if len(pts_orig) >= 3:
+            self.polygonFinished.emit(pts_orig)
         self.update()
         return True
 
@@ -642,9 +645,31 @@ class ImageLabel(QLabel):
             pts_orig = [
                 self.display_to_original(p) for p in self.current_polygon_points
             ]
-            self.polygonFinished.emit(pts_orig)
+            if self._draw_shape == "brush":
+                pts_orig = simplify_polygon(pts_orig, epsilon=1.5)
+
+            if len(pts_orig) >= 3:
+                if self.current_tool == SAM_BBOX:
+                    xs = [p[0] for p in pts_orig]
+                    ys = [p[1] for p in pts_orig]
+                    ox1, ox2 = min(xs), max(xs)
+                    oy1, oy2 = min(ys), max(ys)
+                    
+                    if self._orig_image_bgr is not None:
+                        img_h, img_w = self._orig_image_bgr.shape[:2]
+                        ox1 = max(0.0, min(ox1, float(img_w)))
+                        ox2 = max(0.0, min(ox2, float(img_w)))
+                        oy1 = max(0.0, min(oy1, float(img_h)))
+                        oy2 = max(0.0, min(oy2, float(img_h)))
+
+                    if (ox2 - ox1) > 4 and (oy2 - oy1) > 4:
+                        self.samBboxDrawn.emit(ox1, oy1, ox2, oy2)
+                else:
+                    self.polygonFinished.emit(pts_orig)
 
         self.current_polygon_points.clear()
+        self._shape_start = None
+        self._shape_end = None
         self.update()
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
@@ -656,11 +681,14 @@ class ImageLabel(QLabel):
         Args:
             event (QKeyEvent): The key press event.
         """
-        if self.current_tool == SAM_BBOX:
+        if self.current_tool in (POLYGON, SAM_BBOX):
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
-                self.accept_sam_ghost()
+                if self._sam_ghost is not None:
+                    self.accept_sam_ghost()
+                elif self.current_polygon_points:
+                    self.finish_current_polygon()
                 return
-            if event.key() == Qt.Key_Escape:
+            if event.key() == Qt.Key_Escape and self.current_tool == SAM_BBOX:
                 self.clear_sam_ghost()
                 self.set_tool(None)
                 self.toolCanceled.emit()
@@ -694,7 +722,7 @@ class ImageLabel(QLabel):
         Args:
             event (QMouseEvent): The mouse double-click event.
         """
-        if self.current_tool == POLYGON and self.current_polygon_points:
+        if self.current_tool in (POLYGON, SAM_BBOX) and self.current_polygon_points:
             self.finish_current_polygon()
             return
 
@@ -770,14 +798,6 @@ class ImageLabel(QLabel):
                 event.accept()
                 return
 
-            # --- SAM bbox tool: start rubber-band on press ---
-            if self.current_tool == SAM_BBOX:
-                self._sam_bbox_start = self.view_to_display(pos_view)
-                self._sam_bbox_end = self._sam_bbox_start
-                self._sam_ghost = None
-                self.update()
-                return
-
             pos_disp = self.view_to_display(pos_view)
 
             # --- PRE-CHECK: Identify if we clicked inside any existing polygon ---
@@ -789,8 +809,7 @@ class ImageLabel(QLabel):
                     found_idx = len(self._overlays) - 1 - i
                     break
 
-            # Check AI polygons when no tool is active
-            if self.current_tool != POLYGON and self._ai_overlays:
+            if self.current_tool not in (POLYGON, SAM_BBOX) and self._ai_overlays:
                 ai_hit = -1
                 for i, pts in enumerate(reversed(self._ai_overlays)):
                     if len(pts) >= 3 and QPolygonF(pts).containsPoint(
@@ -808,21 +827,26 @@ class ImageLabel(QLabel):
                     self.update()
                     self.ai_polygon_clicked.emit(-1, pos_view)
 
-            # 1. Normal Polygon Drawing
-            if self.current_tool == POLYGON:
-                # Visually highlight the polygon we clicked on, even while drawing
+            if self.current_tool in (POLYGON, SAM_BBOX):
+                if self.current_tool == SAM_BBOX:
+                    self._sam_ghost = None
+
                 if not self.current_polygon_points:
                     self.selected_polygon_idx = found_idx
                     self.polygonSelected.emit(found_idx)
 
-                if self._near_polygon_start(pos_view):
-                    self.setCursor(Qt.ArrowCursor)
-                    self.finish_current_polygon()
-                    return
+                if self._draw_shape == "point":
+                    if self._near_polygon_start(pos_view):
+                        self.setCursor(Qt.ArrowCursor)
+                        self.finish_current_polygon()
+                        return
+                    self.current_polygon_points.append(pos_disp)
+                elif self._draw_shape == "brush":
+                    self.current_polygon_points.append(pos_disp)
+                elif self._draw_shape in ("rectangle", "circle"):
+                    self._shape_start = pos_disp
+                    self._shape_end = pos_disp
 
-                self.current_polygon_points.append(
-                    self.view_to_display(QPointF(event.pos()))
-                )
                 self.update()
                 return
 
@@ -861,12 +885,6 @@ class ImageLabel(QLabel):
             event.accept()
             return
 
-        # --- SAM bbox rubber-band update ---
-        if self.current_tool == SAM_BBOX and self._sam_bbox_start is not None:
-            self._sam_bbox_end = self.view_to_display(self._mouse_pos)
-            self.update()
-            return
-
         # --- Drag vertex ---
         if self._dragging_vertex_idx != -1:
             new_pos = self.view_to_display(self._mouse_pos)
@@ -875,7 +893,6 @@ class ImageLabel(QLabel):
             self.update()
             return
 
-        # --- Drag entire polygon ---
         if (
             self._dragging_polygon
             and self.selected_polygon_idx != -1
@@ -904,14 +921,29 @@ class ImageLabel(QLabel):
             self.update()
             return
 
-        if self.current_tool == POLYGON and self.current_polygon_points:
-            if self._near_polygon_start(self._mouse_pos):
-                self.setCursor(Qt.CrossCursor)
-            else:
-                self.setCursor(Qt.ArrowCursor)
-            self.update()
+        if self.current_tool in (POLYGON, SAM_BBOX) and (event.buttons() & Qt.LeftButton):
+            if self._draw_shape == "brush":
+                pos_disp = self.view_to_display(self._mouse_pos)
+                if self.current_polygon_points:
+                    last = self.current_polygon_points[-1]
+                    dist = ((pos_disp.x() - last.x())**2 + (pos_disp.y() - last.y())**2)**0.5
+                    if dist > 2.0 / self._zoom:
+                        self.current_polygon_points.append(pos_disp)
+                        self.update()
+            elif self._draw_shape in ("rectangle", "circle"):
+                self._shape_end = self.view_to_display(self._mouse_pos)
+                self.update()
             return
 
+        if self.current_tool in (POLYGON, SAM_BBOX) and self.current_polygon_points:
+            if self._draw_shape in ("point", "brush"):
+                if self._near_polygon_start(self._mouse_pos):
+                    self.setCursor(Qt.CrossCursor)
+                else:
+                    self.setCursor(Qt.ArrowCursor)
+            self.update()
+            return
+        
         if self._center_crop_calibrating and self.current_tool is None:
             self.setCursor(Qt.SizeAllCursor)
         elif self.current_tool is None and self._overlays:
@@ -935,21 +967,29 @@ class ImageLabel(QLabel):
                 event.accept()
                 return
 
-            # --- SAM bbox complete: clear rubber-band and emit original-coords bbox ---
-            if self.current_tool == SAM_BBOX and self._sam_bbox_start is not None:
-                end = self.view_to_display(QPointF(event.pos()))
-                x1 = min(self._sam_bbox_start.x(), end.x())
-                y1 = min(self._sam_bbox_start.y(), end.y())
-                x2 = max(self._sam_bbox_start.x(), end.x())
-                y2 = max(self._sam_bbox_start.y(), end.y())
-                # Clear rubber-band immediately so it disappears on release
-                self._sam_bbox_start = None
-                self._sam_bbox_end = None
-                self.update()
-                if (x2 - x1) > 4 and (y2 - y1) > 4:
-                    ox1, oy1 = self.display_to_original(QPointF(x1, y1))
-                    ox2, oy2 = self.display_to_original(QPointF(x2, y2))
-                    self.samBboxDrawn.emit(ox1, oy1, ox2, oy2)
+            if self.current_tool in (POLYGON, SAM_BBOX):
+                if self._draw_shape == "brush":
+                    self.finish_current_polygon()
+                elif self._draw_shape == "rectangle" and self._shape_start and self._shape_end:
+                    x1, y1 = self._shape_start.x(), self._shape_start.y()
+                    x2, y2 = self._shape_end.x(), self._shape_end.y()
+                    self.current_polygon_points = [
+                        QPointF(x1, y1), QPointF(x2, y1),
+                        QPointF(x2, y2), QPointF(x1, y2)
+                    ]
+                    self.finish_current_polygon()
+                elif self._draw_shape == "circle" and self._shape_start and self._shape_end:
+                    cx, cy = self._shape_start.x(), self._shape_start.y()
+                    dx = self._shape_end.x() - cx
+                    dy = self._shape_end.y() - cy
+                    r = (dx*dx + dy*dy)**0.5
+                    if r > 1.0:
+                        pts = []
+                        for i in range(32):
+                            angle = i * 2 * np.pi / 32
+                            pts.append(QPointF(cx + r * np.cos(angle), cy + r * np.sin(angle)))
+                        self.current_polygon_points = pts
+                        self.finish_current_polygon()
                 return
 
             if self._dragging_vertex_idx != -1:
@@ -1227,24 +1267,26 @@ class ImageLabel(QLabel):
         self._paint_center_crop(painter)
 
         # Draw SAM bounding-box rubber-band while the user is dragging
-        if (
-            self.current_tool == SAM_BBOX
-            and self._sam_bbox_start is not None
-            and self._sam_bbox_end is not None
-        ):
-            from PySide6.QtCore import QRectF
-
-            x1 = min(self._sam_bbox_start.x(), self._sam_bbox_end.x())
-            y1 = min(self._sam_bbox_start.y(), self._sam_bbox_end.y())
-            x2 = max(self._sam_bbox_start.x(), self._sam_bbox_end.x())
-            y2 = max(self._sam_bbox_start.y(), self._sam_bbox_end.y())
-            bbox_color = self._active_color
-            bbox_pen = QPen(bbox_color, 1.5 / self._zoom, Qt.SolidLine)
-            painter.setPen(bbox_pen)
-            fill = QColor(bbox_color.red(), bbox_color.green(), bbox_color.blue(), 30)
-            painter.setBrush(QBrush(fill))
-            painter.drawRect(QRectF(x1, y1, x2 - x1, y2 - y1))
-
+        if self.current_tool in (POLYGON, SAM_BBOX) and self._shape_start and self._shape_end:
+            preview_pen = QPen(self._active_color, self._line_thickness / self._zoom)
+            painter.setPen(preview_pen)
+            
+            if self.current_tool == SAM_BBOX:
+                fill = QColor(self._active_color.red(), self._active_color.green(), self._active_color.blue(), 30)
+                painter.setBrush(QBrush(fill))
+            else:
+                painter.setBrush(Qt.NoBrush)
+                
+            if self._draw_shape == "rectangle":
+                x1, y1 = self._shape_start.x(), self._shape_start.y()
+                x2, y2 = self._shape_end.x(), self._shape_end.y()
+                painter.drawRect(QRectF(min(x1,x2), min(y1,y2), abs(x2-x1), abs(y2-y1)))
+            elif self._draw_shape == "circle":
+                cx, cy = self._shape_start.x(), self._shape_start.y()
+                dx = self._shape_end.x() - cx
+                dy = self._shape_end.y() - cy
+                r = (dx*dx + dy*dy)**0.5
+                painter.drawEllipse(QPointF(cx, cy), r, r)
         # Draw Overlays with Selection Highlighting
         for i, (pts, color, thick, visible) in enumerate(self._overlays):
             if visible and len(pts) >= 2:
@@ -1300,27 +1342,27 @@ class ImageLabel(QLabel):
                 # painter.setFont(f)
                 # painter.drawText(label_pos, f"SAM  {confidence:.2f}")
 
-        if self.current_tool == POLYGON and self.current_polygon_points:
+        if self.current_tool in (POLYGON, SAM_BBOX) and self.current_polygon_points:
             painter.setBrush(Qt.NoBrush)
             painter.setPen(QPen(self._active_color, self._line_thickness / self._zoom))
             painter.drawPolyline(QPolygonF(self.current_polygon_points))
 
-            if self._mouse_pos:
-                cursor_in_disp = self.view_to_display(self._mouse_pos)
-                painter.drawLine(
-                    self.current_polygon_points[-1],
-                    cursor_in_disp,
-                )
+            if self._draw_shape == "point":
+                if self._mouse_pos:
+                    cursor_in_disp = self.view_to_display(self._mouse_pos)
+                    painter.drawLine(
+                        self.current_polygon_points[-1],
+                        cursor_in_disp,
+                    )
 
-            # Draw vertex dots — screen-constant radii by dividing by zoom
-            r_mid = 4.0 / self._zoom
-            r_first = 8.0 / self._zoom
-            outline_pen = QPen(QColor(20, 20, 20), 1.0 / self._zoom)
-            for j, pt in enumerate(self.current_polygon_points):
-                r = r_first if j == 0 else r_mid
-                painter.setBrush(QBrush(self._active_color))
-                painter.setPen(outline_pen)
-                painter.drawEllipse(pt, r, r)
+                r_mid = 4.0 / self._zoom
+                r_first = 8.0 / self._zoom
+                outline_pen = QPen(QColor(20, 20, 20), 1.0 / self._zoom)
+                for j, pt in enumerate(self.current_polygon_points):
+                    r = r_first if j == 0 else r_mid
+                    painter.setBrush(QBrush(self._active_color))
+                    painter.setPen(outline_pen)
+                    painter.drawEllipse(pt, r, r)
 
         self._paint_calib_dots(painter)
 

--- a/src/views/annomate/image_label.py
+++ b/src/views/annomate/image_label.py
@@ -292,6 +292,8 @@ class ImageLabel(QLabel):
         """
         if self.current_tool == SAM_BBOX and tool_name != SAM_BBOX:
             self._sam_ghost = None
+            self._shape_start = None
+            self._shape_end = None
         if self.current_tool in (CALIBRATE, MEASURE) and tool_name not in (
             CALIBRATE,
             MEASURE,
@@ -539,6 +541,8 @@ class ImageLabel(QLabel):
     def clear_sam_ghost(self) -> None:
         """Discard the SAM ghost polygon, bbox, and repaint."""
         self._sam_ghost = None
+        self._shape_start = None
+        self._shape_end = None
         self.update()
 
     def accept_sam_ghost(self) -> bool:
@@ -556,6 +560,8 @@ class ImageLabel(QLabel):
         pts_disp, _ = self._sam_ghost
         pts_orig = [self.display_to_original(p) for p in pts_disp]
         self._sam_ghost = None
+        self._shape_start = None
+        self._shape_end = None
         if len(pts_orig) >= 3:
             self.polygonFinished.emit(pts_orig)
         self.update()

--- a/src/views/annomate/image_label.py
+++ b/src/views/annomate/image_label.py
@@ -654,7 +654,7 @@ class ImageLabel(QLabel):
                     ys = [p[1] for p in pts_orig]
                     ox1, ox2 = min(xs), max(xs)
                     oy1, oy2 = min(ys), max(ys)
-                    
+
                     if self._orig_image_bgr is not None:
                         img_h, img_w = self._orig_image_bgr.shape[:2]
                         ox1 = max(0.0, min(ox1, float(img_w)))
@@ -921,12 +921,16 @@ class ImageLabel(QLabel):
             self.update()
             return
 
-        if self.current_tool in (POLYGON, SAM_BBOX) and (event.buttons() & Qt.LeftButton):
+        if self.current_tool in (POLYGON, SAM_BBOX) and (
+            event.buttons() & Qt.LeftButton
+        ):
             if self._draw_shape == "brush":
                 pos_disp = self.view_to_display(self._mouse_pos)
                 if self.current_polygon_points:
                     last = self.current_polygon_points[-1]
-                    dist = ((pos_disp.x() - last.x())**2 + (pos_disp.y() - last.y())**2)**0.5
+                    dist = (
+                        (pos_disp.x() - last.x()) ** 2 + (pos_disp.y() - last.y()) ** 2
+                    ) ** 0.5
                     if dist > 2.0 / self._zoom:
                         self.current_polygon_points.append(pos_disp)
                         self.update()
@@ -943,7 +947,7 @@ class ImageLabel(QLabel):
                     self.setCursor(Qt.ArrowCursor)
             self.update()
             return
-        
+
         if self._center_crop_calibrating and self.current_tool is None:
             self.setCursor(Qt.SizeAllCursor)
         elif self.current_tool is None and self._overlays:
@@ -970,24 +974,36 @@ class ImageLabel(QLabel):
             if self.current_tool in (POLYGON, SAM_BBOX):
                 if self._draw_shape == "brush":
                     self.finish_current_polygon()
-                elif self._draw_shape == "rectangle" and self._shape_start and self._shape_end:
+                elif (
+                    self._draw_shape == "rectangle"
+                    and self._shape_start
+                    and self._shape_end
+                ):
                     x1, y1 = self._shape_start.x(), self._shape_start.y()
                     x2, y2 = self._shape_end.x(), self._shape_end.y()
                     self.current_polygon_points = [
-                        QPointF(x1, y1), QPointF(x2, y1),
-                        QPointF(x2, y2), QPointF(x1, y2)
+                        QPointF(x1, y1),
+                        QPointF(x2, y1),
+                        QPointF(x2, y2),
+                        QPointF(x1, y2),
                     ]
                     self.finish_current_polygon()
-                elif self._draw_shape == "circle" and self._shape_start and self._shape_end:
+                elif (
+                    self._draw_shape == "circle"
+                    and self._shape_start
+                    and self._shape_end
+                ):
                     cx, cy = self._shape_start.x(), self._shape_start.y()
                     dx = self._shape_end.x() - cx
                     dy = self._shape_end.y() - cy
-                    r = (dx*dx + dy*dy)**0.5
+                    r = (dx * dx + dy * dy) ** 0.5
                     if r > 1.0:
                         pts = []
                         for i in range(32):
                             angle = i * 2 * np.pi / 32
-                            pts.append(QPointF(cx + r * np.cos(angle), cy + r * np.sin(angle)))
+                            pts.append(
+                                QPointF(cx + r * np.cos(angle), cy + r * np.sin(angle))
+                            )
                         self.current_polygon_points = pts
                         self.finish_current_polygon()
                 return
@@ -1267,25 +1283,36 @@ class ImageLabel(QLabel):
         self._paint_center_crop(painter)
 
         # Draw SAM bounding-box rubber-band while the user is dragging
-        if self.current_tool in (POLYGON, SAM_BBOX) and self._shape_start and self._shape_end:
+        if (
+            self.current_tool in (POLYGON, SAM_BBOX)
+            and self._shape_start
+            and self._shape_end
+        ):
             preview_pen = QPen(self._active_color, self._line_thickness / self._zoom)
             painter.setPen(preview_pen)
-            
+
             if self.current_tool == SAM_BBOX:
-                fill = QColor(self._active_color.red(), self._active_color.green(), self._active_color.blue(), 30)
+                fill = QColor(
+                    self._active_color.red(),
+                    self._active_color.green(),
+                    self._active_color.blue(),
+                    30,
+                )
                 painter.setBrush(QBrush(fill))
             else:
                 painter.setBrush(Qt.NoBrush)
-                
+
             if self._draw_shape == "rectangle":
                 x1, y1 = self._shape_start.x(), self._shape_start.y()
                 x2, y2 = self._shape_end.x(), self._shape_end.y()
-                painter.drawRect(QRectF(min(x1,x2), min(y1,y2), abs(x2-x1), abs(y2-y1)))
+                painter.drawRect(
+                    QRectF(min(x1, x2), min(y1, y2), abs(x2 - x1), abs(y2 - y1))
+                )
             elif self._draw_shape == "circle":
                 cx, cy = self._shape_start.x(), self._shape_start.y()
                 dx = self._shape_end.x() - cx
                 dy = self._shape_end.y() - cy
-                r = (dx*dx + dy*dy)**0.5
+                r = (dx * dx + dy * dy) ** 0.5
                 painter.drawEllipse(QPointF(cx, cy), r, r)
         # Draw Overlays with Selection Highlighting
         for i, (pts, color, thick, visible) in enumerate(self._overlays):

--- a/src/views/annomate/sections/annotations.py
+++ b/src/views/annomate/sections/annotations.py
@@ -154,9 +154,7 @@ class _IconButtonDelegate(QStyledItemDelegate):
                 painter, QRectF(button.rect).adjusted(9, 7, -9, -7), opt
             )
 
-    def _paint_eye_icon(
-        self, painter: QPainter, rect: QRectF, opt, index
-    ) -> None:
+    def _paint_eye_icon(self, painter: QPainter, rect: QRectF, opt, index) -> None:
         center = rect.center()
         eye = QPainterPath()
         eye.moveTo(rect.left(), center.y())
@@ -203,9 +201,7 @@ class _IconButtonDelegate(QStyledItemDelegate):
         painter.setRenderHint(QPainter.Antialiasing, True)
         painter.setPen(QPen(opt.palette.buttonText().color(), 1.4))
         painter.setBrush(Qt.NoBrush)
-        painter.drawLine(
-            rect.left() + w * 0.12, lid_y, rect.right() - w * 0.12, lid_y
-        )
+        painter.drawLine(rect.left() + w * 0.12, lid_y, rect.right() - w * 0.12, lid_y)
         painter.drawLine(
             rect.left() + w * 0.38,
             rect.top() + h * 0.08,

--- a/src/views/annomate/sections/classes.py
+++ b/src/views/annomate/sections/classes.py
@@ -142,9 +142,7 @@ class _IconButtonDelegate(QStyledItemDelegate):
             w * 0.64,
             h * 0.62,
         )
-        painter.drawLine(
-            rect.left() + w * 0.12, lid_y, rect.right() - w * 0.12, lid_y
-        )
+        painter.drawLine(rect.left() + w * 0.12, lid_y, rect.right() - w * 0.12, lid_y)
         painter.drawLine(
             rect.left() + w * 0.38,
             rect.top() + h * 0.08,

--- a/src/views/annomate/tool_palette.py
+++ b/src/views/annomate/tool_palette.py
@@ -16,23 +16,8 @@ from PySide6.QtWidgets import (
     QToolButton,
     QButtonGroup,
     QSizePolicy,
-    QMenu,
-    QWidgetAction,
-    QSlider,
-    QLabel,
-    QHBoxLayout,
-    QWidget,
-    QComboBox,
 )
 from PySide6.QtGui import QFont
-
-# Maps human-readable combo label → internal variant key used by SAMStrategy
-_SAM_VARIANT_MAP = {
-    "SAM2.1 Tiny": "sam2_t.pt",
-    "SAM2.1 Small": "sam2_s.pt",
-    "SAM2.1 Base+": "sam2_b.pt",
-    "SAM2.1 Large": "sam2_l.pt",
-}
 
 _BTN_W = 44
 _BTN_H = 40
@@ -48,8 +33,6 @@ class ToolPalette(QFrame):
     """
 
     tool_selected = Signal(str)
-    thickness_changed = Signal(float)
-    sam_variant_changed = Signal(str)
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
@@ -84,40 +67,6 @@ class ToolPalette(QFrame):
         layout.addWidget(poly_btn)
 
         # ------------------------------------------------------------------ #
-        # Brush thickness popup
-        # ------------------------------------------------------------------ #
-        btn_thickness = QToolButton()
-        btn_thickness.setText("◢")
-        btn_thickness.setToolTip("Brush Thickness")
-        btn_thickness.setFixedSize(_BTN_W, _BTN_H)
-        btn_thickness.setFont(font)
-        btn_thickness.setPopupMode(QToolButton.InstantPopup)
-
-        thickness_menu = QMenu(self)
-        thickness_action = QWidgetAction(self)
-        t_container = QWidget()
-        t_h = QHBoxLayout(t_container)
-        t_h.setContentsMargins(8, 4, 8, 4)
-
-        self.slider_thickness = QSlider(Qt.Horizontal)
-        self.slider_thickness.setRange(1, 40)
-        self.slider_thickness.setValue(8)  # 8 × 0.25 = 2.00 px default
-        self.slider_thickness.setTickPosition(QSlider.TickPosition.TicksBelow)
-        self.slider_thickness.setTickInterval(4)
-        self.slider_thickness.setMinimumWidth(150)
-
-        self.lbl_thickness = QLabel("2.00 px")
-        self.lbl_thickness.setFixedWidth(55)
-
-        t_h.addWidget(self.slider_thickness)
-        t_h.addWidget(self.lbl_thickness)
-        thickness_action.setDefaultWidget(t_container)
-        thickness_menu.addAction(thickness_action)
-        btn_thickness.setMenu(thickness_menu)
-        layout.addWidget(btn_thickness)
-        self.slider_thickness.valueChanged.connect(self._on_slider_changed)
-
-        # ------------------------------------------------------------------ #
         # Divider
         # ------------------------------------------------------------------ #
         divider = QFrame()
@@ -138,54 +87,11 @@ class ToolPalette(QFrame):
         self._btn_group.addButton(sam_btn)
         layout.addWidget(sam_btn)
 
-        # ------------------------------------------------------------------ #
-        # SAM options popup
-        # ------------------------------------------------------------------ #
-        btn_sam_opts = QToolButton()
-        btn_sam_opts.setText("⚙")
-        btn_sam_opts.setToolTip("SAM Options")
-        btn_sam_opts.setFixedSize(_BTN_W, _BTN_H)
-        btn_sam_opts.setFont(font)
-        btn_sam_opts.setPopupMode(QToolButton.InstantPopup)
-
-        sam_menu = QMenu(self)
-        sam_action = QWidgetAction(self)
-        sam_container = QWidget()
-        sam_v = QVBoxLayout(sam_container)
-        sam_v.setContentsMargins(8, 6, 8, 6)
-        sam_v.setSpacing(4)
-
-        variant_row = QHBoxLayout()
-        variant_row.addWidget(QLabel("Variant:"))
-        self.sam_variant_combo = QComboBox()
-        self.sam_variant_combo.addItems(list(_SAM_VARIANT_MAP.keys()))
-        self.sam_variant_combo.setToolTip(
-            "SAM 2 model size — tiny is fastest, large is most accurate.\n"
-            "Weights are downloaded to sam_weights/ on first use."
-        )
-        self.sam_variant_combo.setMinimumWidth(130)
-        variant_row.addWidget(self.sam_variant_combo)
-        sam_v.addLayout(variant_row)
-
-        self.sam_status_lbl = QLabel("Model: not loaded")
-        self.sam_status_lbl.setStyleSheet("color: grey; font-style: italic;")
-        sam_v.addWidget(self.sam_status_lbl)
-
-        sam_action.setDefaultWidget(sam_container)
-        sam_menu.addAction(sam_action)
-        btn_sam_opts.setMenu(sam_menu)
-        layout.addWidget(btn_sam_opts)
-        self.sam_variant_combo.currentTextChanged.connect(self._on_sam_combo_changed)
-
         self._btn_group.buttonClicked.connect(self._on_btn_clicked)
 
     # ------------------------------------------------------------------ #
     # Public API
     # ------------------------------------------------------------------ #
-
-    def current_sam_variant(self) -> str:
-        """Return the internal variant key for the currently selected SAM model."""
-        return _SAM_VARIANT_MAP.get(self.sam_variant_combo.currentText(), "sam2_t.pt")
 
     def deselect_all(self) -> None:
         """Uncheck all tool buttons (called when the canvas cancels a tool)."""
@@ -207,9 +113,6 @@ class ToolPalette(QFrame):
     # Internal slots
     # ------------------------------------------------------------------ #
 
-    def _on_sam_combo_changed(self, display_name: str) -> None:
-        self.sam_variant_changed.emit(_SAM_VARIANT_MAP.get(display_name, "sam2_t.pt"))
-
     def _on_btn_clicked(self, btn: QToolButton) -> None:
         tool_name = self._btn_tool.get(btn, "")
         if tool_name == self._active_tool:
@@ -218,11 +121,6 @@ class ToolPalette(QFrame):
         else:
             self._active_tool = tool_name
             self.tool_selected.emit(tool_name)
-
-    def _on_slider_changed(self, value: int) -> None:
-        thickness = value * 0.25
-        self.lbl_thickness.setText(f"{thickness:.2f} px")
-        self.thickness_changed.emit(thickness)
 
     def _toggle_tool(self, tool_name: str) -> None:
         for btn, name in self._btn_tool.items():

--- a/src/views/annomate/viewport_actions.py
+++ b/src/views/annomate/viewport_actions.py
@@ -723,9 +723,7 @@ class ViewportActionsBar(QFrame):
         self._crop_center_dot_chk.setEnabled(self._has_image)
         self._btn_reset_crop.setEnabled(self._has_image)
         self._btn_calibrate_center.setEnabled(self._has_image)
-        self._btn_accept_center.setEnabled(
-            self._has_image and self._center_calibrating
-        )
+        self._btn_accept_center.setEnabled(self._has_image and self._center_calibrating)
         self._btn_clear_template.setEnabled(
             self._center_template_model is not None
             and self._center_template_model.has_template()
@@ -736,9 +734,7 @@ class ViewportActionsBar(QFrame):
         self._color_btn.setEnabled(scale_available)
         self._radio_auto.setEnabled(scale_available)
         self._radio_fixed.setEnabled(scale_available)
-        self._spacing_edit.setEnabled(
-            scale_available and self._radio_fixed.isChecked()
-        )
+        self._spacing_edit.setEnabled(scale_available and self._radio_fixed.isChecked())
         self._btn_clear_measurement.setEnabled(scale_available)
         self._btn_reset_calibration.setEnabled(scale_available)
         if not scale_available and self._active_tool == "measure":

--- a/src/views/annomate/window.py
+++ b/src/views/annomate/window.py
@@ -917,7 +917,10 @@ class AnnoMateWindow(QWidget):
         logger.debug("Applying center template match for row %d.", self._current_row)
         result = self._center_template_controller.match_image(bgr)
         if result is None:
-            logger.debug("Center template match produced no result for row %d.", self._current_row)
+            logger.debug(
+                "Center template match produced no result for row %d.",
+                self._current_row,
+            )
             return
         center_x, center_y, _score = result
         crop = self._center_template_model.crop_settings()
@@ -1003,7 +1006,12 @@ class AnnoMateWindow(QWidget):
                 thick = annos[idx].get("thickness", 2.0)
                 self.canvas.set_line_thickness(thick)
 
-                if self._active_tool not in ("polygon", "sam_bbox", "calibrate", "measure"):
+                if self._active_tool not in (
+                    "polygon",
+                    "sam_bbox",
+                    "calibrate",
+                    "measure",
+                ):
                     self.canvas_toolbar.set_context("edit", thick)
         else:
             if self._active_tool not in ("polygon", "sam_bbox", "calibrate", "measure"):

--- a/src/views/annomate/window.py
+++ b/src/views/annomate/window.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
 )
 
 from views.annomate._splitter import StyledSplitter
+from views.annomate.canvas_toolbar import CanvasToolbar
 
 from views.annomate.image_label import ImageLabel, SAM_BBOX, CALIBRATE, MEASURE
 from views.annomate.right_panel import RightPanel
@@ -478,7 +479,7 @@ class AnnoMateWindow(QWidget):
             lambda *_: self._refresh_canvas_render()
         )
 
-        # Tool palette
+        # Tool palette & Canvas Toolbar
         self.tool_palette.tool_selected.connect(self._on_tool_selected)
         self.viewport_actions.tool_selected.connect(self._on_tool_selected)
         self.viewport_actions.center_calibration_started.connect(
@@ -492,12 +493,12 @@ class AnnoMateWindow(QWidget):
         )
         self.canvas.draw_attempted.connect(self._on_draw_attempted)
 
-        # Route thickness signal directly to canvas setter
-        self.tool_palette.thickness_changed.connect(self._on_thickness_changed)
+        self.canvas_toolbar.thickness_changed.connect(self._on_thickness_changed)
+        self.canvas_toolbar.shape_changed.connect(self.canvas.set_draw_shape)
+        self.canvas_toolbar.sam_variant_changed.connect(self._on_sam_variant_changed)
 
         # SAM tool
         self.canvas.samBboxDrawn.connect(self._on_sam_bbox_drawn)
-        self.tool_palette.sam_variant_changed.connect(self._on_sam_variant_changed)
 
         # Calibration tool
         self.canvas.calibrationPointsPlaced.connect(self._on_calibration_points_placed)
@@ -507,7 +508,7 @@ class AnnoMateWindow(QWidget):
         self._sam_controller.loading_failed.connect(self._on_sam_loading_failed)
 
         # Auto-load SAM silently if the checkpoint is already on disk
-        variant = self.tool_palette.current_sam_variant()
+        variant = self.canvas_toolbar.current_sam_variant()
         logger.info(
             "AnnoMateWindow startup: checking for cached SAM weights (%s)", variant
         )
@@ -551,9 +552,19 @@ class AnnoMateWindow(QWidget):
         splitter.setHandleWidth(8)
         splitter.setChildrenCollapsible(False)
 
-        self.canvas = ImageLabel(self)
+        canvas_container = QWidget()
+        canvas_layout = QVBoxLayout(canvas_container)
+        canvas_layout.setContentsMargins(0, 0, 0, 0)
+        canvas_layout.setSpacing(0)
+
+        self.canvas_toolbar = CanvasToolbar(canvas_container)
+        canvas_layout.addWidget(self.canvas_toolbar)
+
+        self.canvas = ImageLabel(canvas_container)
         self.canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        splitter.addWidget(self.canvas)
+        canvas_layout.addWidget(self.canvas)
+
+        splitter.addWidget(canvas_container)
 
         self.viewport_actions = ViewportActionsBar(
             self.canvas,
@@ -658,6 +669,7 @@ class AnnoMateWindow(QWidget):
             self._ai_popup.setVisible(False)
             self.viewport_actions.set_image_loaded(False)
             self.viewport_actions.set_active_tool("")
+            self.canvas_toolbar.set_context("")
             self.canvas.clear_image()
             self.right_panel.set_current_row(-1)
             self.status_bar.set_class("")
@@ -706,10 +718,11 @@ class AnnoMateWindow(QWidget):
             self._active_tool = "sam_bbox"
             self.viewport_actions.set_active_tool("")
             self.canvas.set_tool(SAM_BBOX)
+            self.canvas_toolbar.set_context("sam_bbox", self.canvas.line_thickness)
             self.status_bar.set_tool("sam_bbox")
             if not self._sam_loading:
                 self._sam_loading = True
-                variant = self.tool_palette.current_sam_variant()
+                variant = self.canvas_toolbar.current_sam_variant()
                 self._sam_controller.set_variant(variant)
                 self.status_bar.set_sam_hint("Loading SAM model…")
                 self._sam_controller.ensure_loaded_async()
@@ -720,6 +733,7 @@ class AnnoMateWindow(QWidget):
             self.tool_palette.deselect_all()
             self.viewport_actions.set_active_tool("calibrate")
             self.canvas.set_tool(CALIBRATE)
+            self.canvas_toolbar.set_context("")
             self.status_bar.set_tool("calibrate")
             return
 
@@ -728,17 +742,28 @@ class AnnoMateWindow(QWidget):
             self.tool_palette.deselect_all()
             self.viewport_actions.set_active_tool("measure")
             self.canvas.set_tool(MEASURE)
+            self.canvas_toolbar.set_context("")
             self.status_bar.set_tool("measure")
             return
 
-        self._active_tool = tool_name
+        if tool_name == "polygon":
+            self._active_tool = "polygon"
+            self.viewport_actions.set_active_tool("")
+            self.canvas.set_tool("polygon")
+            self.canvas_toolbar.set_context("polygon", self.canvas.line_thickness)
+            self.status_bar.set_tool("polygon")
+            return
+
+        self._active_tool = ""
         self.viewport_actions.set_active_tool("")
-        self.canvas.set_tool("polygon" if tool_name == "polygon" else None)
-        self.status_bar.set_tool(tool_name)
+        self.canvas.set_tool(None)
+        self.canvas_toolbar.set_context("")
+        self.status_bar.set_tool("")
 
     def _on_tool_canceled(self) -> None:
         self.tool_palette.deselect_all()
         self.viewport_actions.set_active_tool("")
+        self.canvas_toolbar.set_context("")
         self._active_tool = ""
         self.status_bar.set_tool("")
         self.status_bar.set_sam_hint("")
@@ -763,6 +788,7 @@ class AnnoMateWindow(QWidget):
         self.canvas.set_tool(None)  # clears _pending_calib_pts, resets cursor
         self.tool_palette.deselect_all()
         self.viewport_actions.set_active_tool("")
+        self.canvas_toolbar.set_context("")
         self._active_tool = ""
         self.status_bar.set_tool("")
 
@@ -773,6 +799,7 @@ class AnnoMateWindow(QWidget):
             self.canvas.set_tool(None)
             self.tool_palette.deselect_all()
             self.viewport_actions.set_active_tool("")
+            self.canvas_toolbar.set_context("")
             self._active_tool = ""
             self.status_bar.set_tool("")
             QMessageBox.warning(
@@ -783,6 +810,7 @@ class AnnoMateWindow(QWidget):
             self.canvas.set_tool(None)
             self.tool_palette.deselect_all()
             self.viewport_actions.set_active_tool("")
+            self.canvas_toolbar.set_context("")
             self._active_tool = ""
             self.status_bar.set_tool("")
             QMessageBox.warning(
@@ -803,6 +831,7 @@ class AnnoMateWindow(QWidget):
         self.canvas.set_tool(None)
         self.tool_palette.deselect_all()
         self.viewport_actions.set_active_tool("")
+        self.canvas_toolbar.set_context("")
         self._active_tool = ""
         self.status_bar.set_tool("")
         self.canvas.set_center_crop(
@@ -972,16 +1001,13 @@ class AnnoMateWindow(QWidget):
             annos = self.dataset_model.get_annotations(self._current_row)
             if 0 <= idx < len(annos):
                 thick = annos[idx].get("thickness", 2.0)
-
-                # Block signals so setting the slider doesn't accidentally trigger a drawing update
-                self.tool_palette.slider_thickness.blockSignals(True)
-                self.tool_palette.slider_thickness.setValue(
-                    int(thick * 4)
-                )  # slider is 1-40
-                self.tool_palette.lbl_thickness.setText(f"{thick:.2f} px")
-                self.tool_palette.slider_thickness.blockSignals(False)
-
                 self.canvas.set_line_thickness(thick)
+
+                if self._active_tool not in ("polygon", "sam_bbox", "calibrate", "measure"):
+                    self.canvas_toolbar.set_context("edit", thick)
+        else:
+            if self._active_tool not in ("polygon", "sam_bbox", "calibrate", "measure"):
+                self.canvas_toolbar.set_context("")
 
     def _refresh_overlays(self) -> None:
         """Rebuild canvas overlays from annotations only (no AI polygons)."""
@@ -1012,11 +1038,9 @@ class AnnoMateWindow(QWidget):
 
     def _on_thickness_changed(self, thickness: float) -> None:
         """Apply thickness based on current tool mode."""
-        # Always update the canvas so future drawing uses this thickness
         self.canvas.set_line_thickness(thickness)
 
-        # If we are NOT actively drawing, and a polygon is selected, mutate its data
-        if self._active_tool != "polygon":
+        if self._active_tool not in ("polygon", "sam_bbox"):
             idx = self.canvas.selected_polygon_idx
             if idx != -1 and self._current_row >= 0:
                 self.dataset_model.update_annotation_thickness(
@@ -1325,18 +1349,12 @@ class AnnoMateWindow(QWidget):
     def _on_sam_variant_changed(self, variant: str) -> None:
         self._sam_controller.set_variant(variant)
         self._sam_loading = False
-        self.tool_palette.sam_status_lbl.setText("Model: not loaded")
-        self.tool_palette.sam_status_lbl.setStyleSheet(
-            "color: grey; font-style: italic;"
-        )
+        self.canvas_toolbar.set_sam_status("Model: not loaded", "grey")
 
     def _on_sam_loading_done(self) -> None:
         self._sam_loading = False
-        display_name = self.tool_palette.sam_variant_combo.currentText()
-        self.tool_palette.sam_status_lbl.setText(f"Ready: {display_name}")
-        self.tool_palette.sam_status_lbl.setStyleSheet(
-            "color: green; font-style: normal;"
-        )
+        display_name = self.canvas_toolbar._combo_sam.currentText()
+        self.canvas_toolbar.set_sam_status(f"Ready: {display_name}", "green")
         self.status_bar.set_sam_hint(f"Ready: {display_name}  ·  draw bbox to segment")
 
     def _on_sam_loading_failed(self, msg: str) -> None:
@@ -1344,12 +1362,10 @@ class AnnoMateWindow(QWidget):
         self.tool_palette.deselect_all()
         self._active_tool = ""
         self.canvas.set_tool(None)
+        self.canvas_toolbar.set_context("")
         self.status_bar.set_tool("")
         self.status_bar.set_sam_hint("")
-        self.tool_palette.sam_status_lbl.setText("Load failed")
-        self.tool_palette.sam_status_lbl.setStyleSheet(
-            "color: red; font-style: normal;"
-        )
+        self.canvas_toolbar.set_sam_status("Load failed", "red")
         QMessageBox.critical(self, "SAM Load Error", f"Could not load model:\n{msg}")
 
     def _on_sam_bbox_drawn(self, x1: float, y1: float, x2: float, y2: float) -> None:


### PR DESCRIPTION
Moved brush thickness and SAM model selection to a collapsible settings toolbar as well as the addition of different bounding box styles like a rectangle, circle, point-by-point (for SAM) and free brush. 