### PR TITLE
Fix to CI/CD process that ignored testing in staging branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - staging
   pull_request:
     branches:
       - main
+      - staging
 
 jobs:
   # -------------------------------------------------------------------------
@@ -16,6 +18,7 @@ jobs:
   lint:
     name: Lint & Format (Ruff via pre-commit)
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.base_ref == 'main')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,6 +44,7 @@ jobs:
   test:
     name: Test on ${{ matrix.os }} with Python 3.10
     needs: lint
+    if: always() && (needs.lint.result == 'success' || needs.lint.result == 'skipped')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fixing CI/CD testing flow issue. In its previous state platform testing would only occur when a change is pushed / pulled into main. This was not the intended approach